### PR TITLE
HIA-553: 🐛 Fix invalid Swagger docs security schemes for endpoints

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/PrisonerDifferencesResource.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/PrisonerDifferencesResource.kt
@@ -32,7 +32,7 @@ class PrisonerDifferencesResource(private val prisonerDifferencesService: Prison
       Find all prisoner differences since a given date time.  This defaults to within the last 24 hours.
       Requires PRISONER_INDEX role.
       """,
-    security = [SecurityRequirement(name = "PRISONER_INDEX")],
+    security = [SecurityRequirement(name = "prisoner-index-role")],
     responses = [
       ApiResponse(
         responseCode = "200",

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/config/OpenApiConfiguration.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/config/OpenApiConfiguration.kt
@@ -54,16 +54,57 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     )
     .components(
       Components().addSecuritySchemes(
-        "bearer-jwt",
+        "view-prisoner-data-role",
         SecurityScheme()
           .type(SecurityScheme.Type.HTTP)
           .scheme("bearer")
           .bearerFormat("JWT")
           .`in`(SecurityScheme.In.HEADER)
-          .name("Authorization"),
+          .name("Authorization")
+          .description("A HMPPS Auth access token with the `ROLE_VIEW_PRISONER_DATA` role."),
+      ).addSecuritySchemes(
+        "prisoner-search-role",
+        SecurityScheme()
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+          .`in`(SecurityScheme.In.HEADER)
+          .name("Authorization")
+          .description("A HMPPS Auth access token with the `ROLE_PRISONER_SEARCH` role."),
+      ).addSecuritySchemes(
+        "global-search-role",
+        SecurityScheme()
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+          .`in`(SecurityScheme.In.HEADER)
+          .name("Authorization")
+          .description("A HMPPS Auth access token with the `ROLE_GLOBAL_SEARCH` role."),
+      ).addSecuritySchemes(
+        "prisoner-in-prison-search-role",
+        SecurityScheme()
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+          .`in`(SecurityScheme.In.HEADER)
+          .name("Authorization")
+          .description("A HMPPS Auth access token with the `ROLE_PRISONER_IN_PRISON_SEARCH` role."),
+      ).addSecuritySchemes(
+        "prisoner-index-role",
+        SecurityScheme()
+          .type(SecurityScheme.Type.HTTP)
+          .scheme("bearer")
+          .bearerFormat("JWT")
+          .`in`(SecurityScheme.In.HEADER)
+          .name("Authorization")
+          .description("A HMPPS Auth access token with the `PRISONER_INDEX` role."),
       ),
     )
-    .addSecurityItem(SecurityRequirement().addList("bearer-jwt", listOf("read", "write")))
+    .addSecurityItem(SecurityRequirement().addList("view-prisoner-data-role", listOf("read")))
+    .addSecurityItem(SecurityRequirement().addList("prisoner-search-role", listOf("read")))
+    .addSecurityItem(SecurityRequirement().addList("global-search-role", listOf("read")))
+    .addSecurityItem(SecurityRequirement().addList("prisoner-in-prison-search-role", listOf("read")))
+    .addSecurityItem(SecurityRequirement().addList("prisoner-index-role", listOf("read", "write")))
 
   @Bean
   fun openAPICustomiser(): OpenApiCustomizer = OpenApiCustomizer {

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/GlobalSearchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/GlobalSearchResource.kt
@@ -51,7 +51,7 @@ class GlobalSearchResource(
   @Operation(
     summary = "Get prisoner by prisoner number (AKA NOMS number)",
     description = "Requires ROLE_PRISONER_SEARCH or ROLE_VIEW_PRISONER_DATA role",
-    security = [SecurityRequirement(name = "ROLE_VIEW_PRISONER_DATA"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "view-prisoner-data-role"), SecurityRequirement(name = "prisoner-search-role")],
   )
   @Tag(name = "Popular")
   fun findByPrisonNumber(@PathVariable id: String): Prisoner? =

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PhysicalDetailResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PhysicalDetailResource.kt
@@ -43,7 +43,7 @@ class PhysicalDetailResource(private val physicalDetailService: PhysicalDetailSe
       prisoner number.
       Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.
       """,
-    security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "global-search-role"), SecurityRequirement(name = "prisoner-search-role")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResource.kt
@@ -37,7 +37,7 @@ class PrisonerDetailResource(private val prisonerDetailService: PrisonerDetailSe
       The '?' symbol will match any letter substituted at that position. e.g. firstName='t?ny' will match 'Tony' and 'Tiny'
       Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.
       """,
-    security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "global-search-role"), SecurityRequirement(name = "prisoner-search-role")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerKeywordResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerKeywordResource.kt
@@ -42,7 +42,7 @@ class PrisonerKeywordResource(private val keywordService: KeywordService) {
       Identifiers within the [and, or, not, exact] terms are detected and converted to the appropriate case.
       Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.
       """,
-    security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "global-search-role"), SecurityRequirement(name = "prisoner-search-role")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerMatchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerMatchResource.kt
@@ -33,7 +33,7 @@ class PrisonerMatchResource(private val matchService: MatchService) {
   @Operation(
     summary = "Match for an prisoner by criteria. This is a more lenient version to other match endpoints that includes alias and fuzzy date of birth matching. It will return the best group of matching prisoners based on the request",
     description = "Specify the request criteria to match against, role required is ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH",
-    security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "global-search-role"), SecurityRequirement(name = "prisoner-search-role")],
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [
         Content(

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonersInPrisonResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonersInPrisonResource.kt
@@ -78,7 +78,7 @@ class PrisonersInPrisonResource(private val searchService: PrisonersInPrisonServ
       This will return all people in HMP Wandsworth. With the alerts TACT or PEEP.
 
       """,
-    security = [SecurityRequirement(name = "ROLE_PRISONER_IN_PRISON_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    security = [SecurityRequirement(name = "prisoner-in-prison-search-role"), SecurityRequirement(name = "prisoner-search-role")],
 
     responses = [
       ApiResponse(

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/OpenApiDocsTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/OpenApiDocsTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.resource
 
 import net.minidev.json.JSONArray
+import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.prisonersearch.search.integration.IntegrationTestBase
@@ -51,19 +52,92 @@ class OpenApiDocsTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `the security scheme is setup for bearer tokens`() {
-    val bearerJwts = JSONArray()
-    bearerJwts.addAll(listOf("read", "write"))
+  fun `a security scheme is setup for a HMPPS Auth token with the ROLE_VIEW_PRISONER_DATA role`() {
+    val viewPrisonerDataRole = JSONArray()
+    viewPrisonerDataRole.addAll(listOf("read"))
     webTestClient.get()
       .uri("/v3/api-docs")
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
       .expectBody()
-      .jsonPath("$.components.securitySchemes.bearer-jwt.type").isEqualTo("http")
-      .jsonPath("$.components.securitySchemes.bearer-jwt.scheme").isEqualTo("bearer")
-      .jsonPath("$.components.securitySchemes.bearer-jwt.bearerFormat").isEqualTo("JWT")
-      .jsonPath("$.security[0].bearer-jwt")
-      .isEqualTo(bearerJwts)
+      .jsonPath("$.components.securitySchemes.view-prisoner-data-role.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.view-prisoner-data-role.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.view-prisoner-data-role.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.components.securitySchemes.view-prisoner-data-role.description").value(Matchers.containsString("ROLE_VIEW_PRISONER_DATA"))
+      .jsonPath("$.security[0].view-prisoner-data-role")
+      .isEqualTo(viewPrisonerDataRole)
+  }
+
+  @Test
+  fun `a security scheme is setup for a HMPPS Auth token with the ROLE_PRISONER_SEARCH role`() {
+    val prisonerSearchRole = JSONArray()
+    prisonerSearchRole.addAll(listOf("read"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.prisoner-search-role.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.prisoner-search-role.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.prisoner-search-role.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.components.securitySchemes.prisoner-search-role.description").value(Matchers.containsString("ROLE_PRISONER_SEARCH"))
+      .jsonPath("$.security[1].prisoner-search-role")
+      .isEqualTo(prisonerSearchRole)
+  }
+
+  @Test
+  fun `a security scheme is setup for a HMPPS Auth token with the ROLE_GLOBAL_SEARCH role`() {
+    val globalSearchRole = JSONArray()
+    globalSearchRole.addAll(listOf("read"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.global-search-role.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.global-search-role.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.global-search-role.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.components.securitySchemes.global-search-role.description").value(Matchers.containsString("ROLE_GLOBAL_SEARCH"))
+      .jsonPath("$.security[2].global-search-role")
+      .isEqualTo(globalSearchRole)
+  }
+
+  @Test
+  fun `a security scheme is setup for a HMPPS Auth token with the ROLE_PRISONER_IN_PRISON_SEARCH role`() {
+    val prisonerInPrisonSearchRole = JSONArray()
+    prisonerInPrisonSearchRole.addAll(listOf("read"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.prisoner-in-prison-search-role.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.prisoner-in-prison-search-role.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.prisoner-in-prison-search-role.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.components.securitySchemes.prisoner-in-prison-search-role.description").value(Matchers.containsString("ROLE_PRISONER_IN_PRISON_SEARCH"))
+      .jsonPath("$.security[3].prisoner-in-prison-search-role")
+      .isEqualTo(prisonerInPrisonSearchRole)
+  }
+
+  @Test
+  fun `a security scheme is setup for a HMPPS Auth token with the PRISONER_INDEX role`() {
+    val prisonerIndexRole = JSONArray()
+    prisonerIndexRole.addAll(listOf("read", "write"))
+    webTestClient.get()
+      .uri("/v3/api-docs")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+      .jsonPath("$.components.securitySchemes.prisoner-index-role.type").isEqualTo("http")
+      .jsonPath("$.components.securitySchemes.prisoner-index-role.scheme").isEqualTo("bearer")
+      .jsonPath("$.components.securitySchemes.prisoner-index-role.bearerFormat").isEqualTo("JWT")
+      .jsonPath("$.components.securitySchemes.prisoner-index-role.description").value(Matchers.containsString("PRISONER_INDEX"))
+      .jsonPath("$.security[4].prisoner-index-role")
+      .isEqualTo(prisonerIndexRole)
   }
 }


### PR DESCRIPTION
## Context

In [HMPPS Integration API](https://github.com/ministryofjustice/hmpps-integration-api), we create simulators based on an upstream API's OpenAPI spec using [Prism](https://stoplight.io/open-source/prism) for our smoke tests. Recently we noticed it was failing.

Upon investigation, we realised that security requirements for endpoints within Prisoner Offender Search referred to security schemes that don't exist. This meant that in the Swagger Docs, no "available authorizations" showed for the
endpoint and the OpenAPI spec JSON was invalid (checked by copying it into [Swagger Editor](https://editor.swagger.io/)).

It seems a [recent change in Prism](https://github.com/stoplightio/prism/blob/master/CHANGELOG.md#540-20231009) meant that it doesn't like when invalid [security schemes](https://swagger.io/docs/specification/authentication/) are defined. As a result, our smoke tests failed because Docker Compose is unable to health check Prisoner Offender Search as it was now returning a 401.

Replicated from: https://github.com/ministryofjustice/prisoner-offender-search/pull/515.

## Changes proposed in this PR

- Remove generic `bearer-jwt` security scheme and replace it within a security scheme per access role.
- Update each endpoint with an invalid security requirement with the corresponding security scheme for the role needed to access the endpoint.

For bearer token authorisation, it's not possible to define a scope/role within OpenAPI so a security scheme per access role had to be taken, see [Swagger docs for bearer authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/).

### Swagger docs

https://github.com/ministryofjustice/prisoner-offender-search/assets/42817036/6ed88c75-cbee-48fb-ab7a-179897695def

### OpenAPI spec JSON

https://github.com/ministryofjustice/prisoner-offender-search/assets/42817036/8855da0a-cf29-4a08-ad4e-c8744ff0ae83

