### PR TITLE
SDIT-1361 Delay sending all domain events by 2 seconds

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventPublisherListener.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventPublisherListener.kt
@@ -1,21 +1,44 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.indexer.listeners
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.awspring.cloud.sqs.annotation.SqsListener
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service
-class DomainEventPublisherListener() {
+class DomainEventPublisherListener(
+  private val objectMapper: ObjectMapper,
+  private val hmppsQueueService: HmppsQueueService,
+) {
+  private inline fun <reified T> fromJson(message: String?): T = objectMapper.readValue(message, T::class.java)
+
+  private val hmppsDomainTopic by lazy {
+    hmppsQueueService.findByTopicId("hmppseventtopic") ?: throw IllegalStateException("hmppseventtopic not found")
+  }
+  private val topicArn by lazy { hmppsDomainTopic.arn }
+  private val topicSnsClient by lazy { hmppsDomainTopic.snsClient }
+
   @SqsListener("publish", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "syscon-devs-hmpps_prisoner_search_publish_queue", kind = SpanKind.SERVER)
-  fun publish(requestJson: String) {
-    log.debug("Received $requestJson - TODO SNS publish")
-  }
+  fun publish(eventJson: String) {
+    println(eventJson)
+    val event = fromJson<DomainEvent>(eventJson)
 
-  private companion object {
-    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    val request = PublishRequest.builder()
+      .topicArn(topicArn)
+      .message(event.body)
+      .messageAttributes(
+        mapOf(
+          "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.eventType).build(),
+        ),
+      ).build()
+
+    topicSnsClient.publish(request)
   }
 }
+
+data class DomainEvent(val eventType: String, val body: String)

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventPublisherListener.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventPublisherListener.kt
@@ -25,7 +25,6 @@ class DomainEventPublisherListener(
   @SqsListener("publish", factory = "hmppsQueueContainerFactoryProxy")
   @WithSpan(value = "syscon-devs-hmpps_prisoner_search_publish_queue", kind = SpanKind.SERVER)
   fun publish(eventJson: String) {
-    println(eventJson)
     val event = fromJson<DomainEvent>(eventJson)
 
     val request = PublishRequest.builder()

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
@@ -73,7 +73,7 @@ class HmppsDomainEventEmitter(
       .build()
 
     runCatching {
-      publishSqsClient.sendMessage(request).get()
+      publishSqsClient.sendMessage(request).join()
       telemetryClient.trackEvent(event.eventType, event.asMap(), null)
     }.onFailure(onFailure)
   }

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
@@ -73,7 +73,7 @@ class HmppsDomainEventEmitter(
       .build()
 
     runCatching {
-      publishSqsClient.sendMessage(request).join()
+      publishSqsClient.sendMessage(request).get()
       telemetryClient.trackEvent(event.eventType, event.asMap(), null)
     }.onFailure(onFailure)
   }

--- a/hmpps-prisoner-search-indexer/src/main/resources/application.yml
+++ b/hmpps-prisoner-search-indexer/src/main/resources/application.yml
@@ -109,3 +109,6 @@ diff:
 
 republish:
   delayInSeconds: 5
+
+publish:
+  delayInSeconds: 2

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/IntegrationTestBase.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/IntegrationTestBase.kt
@@ -194,6 +194,18 @@ abstract class IntegrationTestBase {
         hmppsQueueFactory.createSqsAsyncClient(config, hmppsSqsProperties, offenderQueueSqsDlqClient)
       }
 
+    @Bean("publish-sqs-client")
+    fun publishSqsClient(
+      hmppsSqsProperties: HmppsSqsProperties,
+      @Qualifier("publish-sqs-dlq-client") publishSqsDlqClient: SqsAsyncClient,
+
+    ): SqsAsyncClient =
+      with(hmppsSqsProperties) {
+        val config = queues["publish"]
+          ?: throw MissingQueueException("HmppsSqsProperties config for publish not found")
+        hmppsQueueFactory.createSqsAsyncClient(config, hmppsSqsProperties, publishSqsDlqClient)
+      }
+
     @Bean("hmppsdomainqueue-sqs-client")
     fun hmppsDomainQueueSqsClient(
       hmppsSqsProperties: HmppsSqsProperties,

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventsEmitterIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventsEmitterIntTest.kt
@@ -448,7 +448,9 @@ class HmppsDomainEventsEmitterIntTest : IntegrationTestBase() {
     await untilAsserted { verify(prisonerDifferenceService).handleDifferences(anyOrNull(), any(), any(), any()) }
 
     // but there is only 1 message on the domain queue because the last update was ignored
-    assertThat(getNumberOfMessagesCurrentlyOnDomainQueue()).isEqualTo(1)
+    await untilAsserted {
+      assertThat(getNumberOfMessagesCurrentlyOnDomainQueue()).isEqualTo(1)
+    }
   }
 
   /*

--- a/hmpps-prisoner-search-indexer/src/test/resources/application-test.yml
+++ b/hmpps-prisoner-search-indexer/src/test/resources/application-test.yml
@@ -77,3 +77,6 @@ diff:
 
 republish:
   delayInSeconds: 0
+
+publish:
+  delayInSeconds: 1


### PR DESCRIPTION
- OpenSearch is updated automatically after a document update but is not flushed to disk, therefore, by the time a domain event is raised indicating that the datastore has been updated can be published before changes are flushed, therefore call backs using the search API can retrieve stale results
- OpenSearch does flush changes every 1 second so by delaying the publish by at least 1 second should guarantee updates have been flushed by the time clients receive the associated domain events