### PR TITLE
SDIT-1490 Add Open API docs and limit to single top level query

### DIFF
--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
@@ -1,8 +1,15 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.resource
 
-import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
@@ -10,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.prisonersearch.search.resource.advice.ErrorResponse
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchService
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.AttributeSearchRequest
 
@@ -24,11 +32,142 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesear
 class AttributeSearchResource(private val attributeSearchService: AttributeSearchService) {
 
   @PostMapping
+  @Tag(name = "Attribute search")
   @Operation(
-    summary = "WIP - DO NOT USE Search for prisoners by attributes",
-    description = "Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role",
+    summary = "WIP - DO NOT USE!!! Search for prisoners by attributes",
+    description = """This endpoint allows you to create queries over all attributes from the [Prisoner] record. Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.
+      
+      The request contains a query to search on one or more attributes using a list of matchers. For example attribute "lastName""
+      requires a [StringMatcher] so we can query on "lastName IS Smith". Other type matchers include [IntMatcher], [BooleanMatcher],
+      [DateMatcher] and [DateTimeMatcher]. We have the facility to easily create additional matchers as required, for example 
+      we may end up with a PNCMatcher that handles any format of PNC number.
+      
+      Each query can also contain a list of sub-queries. Each sub-query can be considered as a separate query in brackets.
+      Combining multiple sub-queries gives us the ability to create complex searches using any combination of a prisoner's 
+      attributes. For example we can model queries such as "lastName IS Smith AND (prisonId IS MDI OR prisonId IS LEI)".
+      
+      To find all attributes that can be searched for please refer to the [Prisoner] record. Attributes from lists can be
+      searched for with dot notation, e.g. "attribute=aliases.firstName" or "attribute=tattoos.bodyPart". Attributes from
+      complex objects can also be searched for with dot notation, e.g. "attribute=currentIncentive.level.code".
+      
+      Example Requests:
+      
+      Search for all prisoners in Moorland with a height between 150 and 180cm
+      
+      Query: "prisonId IS "MDI" AND (heightCentimetres BETWEEN 150 AND 180)"
+      
+      JSON request:
+      {
+        "queries": [
+          {
+            "joinType"" "AND",
+            "matchers": [
+              {
+                "type": "String",
+                "attribute": "prisonId",
+                "condition": "IS",
+                "searchTerm": "MDI"
+              },
+              {
+                "type": "Int",
+                "attribute": "heightCentimetres",
+                "minValue": 150,
+                "maxValue": 180
+              }
+            ],
+          }
+        ]
+      }
+      
+      
+      Search for all prisoners received since 1st Jan 2024 with a dragon tattoo on either their arm or shoulder
+      
+      Query: "receptionDate >= 2024-01-01 AND ((tattoos.bodyPart IS "arm" AND tattoos.comment CONTAINS "dragon" ) OR (tattoos.bodyPart IS "shoulder" AND tattoos.comment CONTAINS "dragon"))"
+      
+      JSON request:
+      {
+        "queries": [
+          {
+            "joinType"" "AND",
+            "matchers": [
+              {
+                "type": "Date",
+                "attribute": "receptionDate",
+                "minValue": "2024-01-01"
+              }
+            [,
+            "subQueries": [
+              {
+                "joinType"" "OR",
+                "subQueries": [
+                  {
+                    "joinType"" "AND",
+                    "matchers": [
+                      {
+                        "type": "String",
+                        "attribute": "tattoos.bodyPart",
+                        "condition": "IS",
+                        "searchTerm": "arm"
+                      },
+                      {
+                        "type": "String",
+                        "attribute": "tattoos.comment",
+                        "condition": "CONTAINS",
+                        "searchTerm": "dragon"
+                      }
+                    ]
+                  },
+                  {
+                    "joinType"" "AND",
+                    "matchers": [
+                      {
+                        "type": "String",
+                        "attribute": "tattoos.bodyPart",
+                        "condition": "IS",
+                        "searchTerm": "shoulder"
+                      },
+                      {
+                        "type": "String",
+                        "attribute": "tattoos.comment",
+                        "condition": "CONTAINS",
+                        "searchTerm": "dragon"
+                      }
+                    ]
+                  }
+                ]    
+              }
+            ]
+          }
+        ]
+      }
+      
+    """,
+    security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Search successfully performed",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect information provided to perform an attribute search",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
   )
-  @Hidden // TODO SDIT-1490 remove when the OpenAPI docs have been written
-  fun attributeSearch(@Parameter(required = true) @RequestBody request: AttributeSearchRequest) =
-    attributeSearchService.search(request)
+  fun attributeSearch(
+    @Parameter(required = true) @RequestBody request: AttributeSearchRequest,
+    @ParameterObject @PageableDefault pageable: Pageable,
+  ) =
+    attributeSearchService.search(request, pageable)
 }

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
@@ -34,29 +34,29 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
   @PostMapping
   @Tag(name = "Attribute search")
   @Operation(
-    summary = "WIP - DO NOT USE!!! Search for prisoners by attributes",
-    description = """This endpoint allows you to create queries over all attributes from the [Prisoner] record. Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.
-      
-      The request contains a query to search on one or more attributes using a list of matchers. For example attribute "lastName""
-      requires a [StringMatcher] so we can query on "lastName IS Smith". Other type matchers include [IntMatcher], [BooleanMatcher],
-      [DateMatcher] and [DateTimeMatcher]. We have the facility to easily create additional matchers as required, for example 
+    summary = "*** WIP - DO NOT USE!!! *** Search for prisoners by attributes",
+    description = """<p>This endpoint allows you to create queries over all attributes from the <em>Prisoner</em> record. Requires ROLE_GLOBAL_SEARCH or ROLE_PRISONER_SEARCH role.</p>
+      <p>The request contains a query to search on one or more attributes using a list of matchers. For example attribute "lastName""
+      requires a <em>StringMatcher</em> so we can query on <strong>"lastName IS Smith"</strong>. Other type matchers include <em>IntMatcher</em>, <em>BooleanMatcher</em>,
+      <em>DateMatcher</em> and <em>DateTimeMatcher</em>. We have the facility to easily create additional matchers as required, for example 
       we may end up with a PNCMatcher that handles any format of PNC number.
-      
-      Each query can also contain a list of sub-queries. Each sub-query can be considered as a separate query in brackets.
+      </p>
+      <p>Each query can also contain a list of sub-queries. Each sub-query can be considered as a separate query in brackets.
       Combining multiple sub-queries gives us the ability to create complex searches using any combination of a prisoner's 
-      attributes. For example we can model queries such as "lastName IS Smith AND (prisonId IS MDI OR prisonId IS LEI)".
-      
-      To find all attributes that can be searched for please refer to the [Prisoner] record. Attributes from lists can be
-      searched for with dot notation, e.g. "attribute=aliases.firstName" or "attribute=tattoos.bodyPart". Attributes from
-      complex objects can also be searched for with dot notation, e.g. "attribute=currentIncentive.level.code".
-      
-      Example Requests:
-      
-      Search for all prisoners in Moorland with a height between 150 and 180cm
-      
-      Query: "prisonId IS "MDI" AND (heightCentimetres BETWEEN 150 AND 180)"
-      
+      attributes. For example we can model queries such as <strong>"lastName IS Smith AND (prisonId IS MDI OR prisonId IS LEI)"</strong>.
+      </p>
+      <p>To find all attributes that can be searched for please refer to the <em>Prisoner</em> record. Attributes from lists can be
+      searched for with dot notation, e.g. <strong>"attribute=aliases.firstName"</strong> or <strong>"attribute=tattoos.bodyPart"</strong>. 
+      Attributes from complex objects can also be searched for with dot notation, e.g. <strong>"attribute=currentIncentive.level.code"</strong>.
+      </p>
+      <h3>Example Requests</h3>
+      <h4>Search for all prisoners in Moorland with a height between 150 and 180cm</h4>
+      <br/>
+      Query: <strong>"prisonId IS "MDI" AND (heightCentimetres BETWEEN 150 AND 180)"</strong>
+      <br/>
       JSON request:
+      <br/>
+      <pre>
       {
         "queries": [
           {
@@ -78,13 +78,14 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
           }
         ]
       }
-      
-      
-      Search for all prisoners received since 1st Jan 2024 with a dragon tattoo on either their arm or shoulder
-      
-      Query: "receptionDate >= 2024-01-01 AND ((tattoos.bodyPart IS "arm" AND tattoos.comment CONTAINS "dragon" ) OR (tattoos.bodyPart IS "shoulder" AND tattoos.comment CONTAINS "dragon"))"
-      
+      </pre>
+      <h4>Search for all prisoners received since 1st Jan 2024 with a dragon tattoo on either their arm or shoulder</h4>
+      <br/>
+      Query: <strong>"receptionDate >= 2024-01-01 AND ((tattoos.bodyPart IS "arm" AND tattoos.comment CONTAINS "dragon" ) OR (tattoos.bodyPart IS "shoulder" AND tattoos.comment CONTAINS "dragon"))"</strong>
+      <br/>
       JSON request:
+      <br/>
+      <pre>
       {
         "queries": [
           {
@@ -140,7 +141,7 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
           }
         ]
       }
-      
+      </pre>
     """,
     security = [SecurityRequirement(name = "ROLE_GLOBAL_SEARCH"), SecurityRequirement(name = "ROLE_PRISONER_SEARCH")],
     responses = [

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
@@ -58,7 +58,7 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
       <br/>
       <pre>
       {
-        "queries": [
+        "query":
           {
             "joinType"" "AND",
             "matchers": [
@@ -76,7 +76,6 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
               }
             ],
           }
-        ]
       }
       </pre>
       <h4>Search for all prisoners received since 1st Jan 2024 with a dragon tattoo on either their arm or shoulder</h4>
@@ -87,7 +86,7 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
       <br/>
       <pre>
       {
-        "queries": [
+        "query":
           {
             "joinType"" "AND",
             "matchers": [
@@ -137,7 +136,6 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
                   }
                 ]    
               }
-            ]
           }
         ]
       }

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchService.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesea
 
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.AttributeSearchRequest
 
@@ -10,9 +11,9 @@ class AttributeSearchService(
   private val attributes: Attributes,
 ) {
 
-  fun search(request: AttributeSearchRequest) {
+  fun search(request: AttributeSearchRequest, pageable: Pageable = Pageable.unpaged()) {
     request.validate(attributes)
-    log.info("searchByAttributes called with request: $request")
+    log.info("searchByAttributes called with request: $request, pageable: $pageable")
   }
 
   private companion object {

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/AttributeSearchRequest.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/AttributeSearchRequest.kt
@@ -1,17 +1,19 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.Attributes
+import uk.gov.justice.digital.hmpps.prisonersearch.search.services.dto.PaginationRequest
 
+@Schema(description = "A request to search for prisoners by attributes")
 data class AttributeSearchRequest(
-  val queries: List<Query>,
+  @Schema(description = "A query to search for prisoners by attributes")
+  val query: Query,
+  val pagination: PaginationRequest = PaginationRequest(0, 10),
 ) {
   fun validate(attributes: Attributes) {
-    if (queries.isEmpty()) {
-      throw AttributeSearchException("At least one matcher must be provided")
-    }
-    queries.getAllQueries().forEach { it.validate() }
-    queries.getAllTypeMatchers()
+    listOf(query).getAllQueries().forEach { it.validate() }
+    listOf(query).getAllTypeMatchers()
       .forEach {
         it.validateType(attributes)
         it.validate()

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/BooleanMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/BooleanMatcher.kt
@@ -1,6 +1,14 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "A matcher for a boolean attribute from the Prisoner record")
 data class BooleanMatcher(
+  @Schema(description = "The attribute to match", example = "recall")
   override val attribute: String,
+  @Schema(description = "Whether the attribute must be true or false", example = "true")
   val condition: Boolean,
-) : TypeMatcher<Boolean>
+) : TypeMatcher<Boolean> {
+  @Schema(description = "Must be Boolean", example = "Boolean")
+  override val type: String = "Boolean"
+}

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateMatcher.kt
@@ -1,15 +1,36 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 import java.time.LocalDate
 
+@Schema(
+  description = """A matcher for a date attribute from the Prisoner record.
+  
+  For a between clause use both min value and max value. By default the range is inclusive, but can be adjusted with minInclusive and maxInclusive.
+  
+  For <= enter only a max value, and for < set max inclusive to false.
+   
+  For >= enter only a min value, and for > set min inclusive to false.
+  
+  For equals enter the same date in both the min value and max value and leave min/max inclusive as true.
+  """,
+)
 data class DateMatcher(
+  @Schema(description = "The attribute to match", example = "releaseDate")
   override val attribute: String,
+  @Schema(description = "The minimum value to match", example = "2024-01-01")
   val minValue: LocalDate? = null,
+  @Schema(description = "Whether the minimum value is inclusive or exclusive", defaultValue = "true")
   val minInclusive: Boolean = true,
+  @Schema(description = "The maximum value to match", example = "2024-01-31")
   val maxValue: LocalDate? = null,
+  @Schema(description = "Whether the maximum value is inclusive or exclusive", defaultValue = "true")
   val maxInclusive: Boolean = true,
 ) : TypeMatcher<LocalDate> {
+  @Schema(description = "Must be Date", example = "Date")
+  override val type: String = "Date"
+
   override fun validate() {
     if (minValue == null && maxValue == null) {
       throw AttributeSearchException("Attribute $attribute must have a min or max value")

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcher.kt
@@ -1,13 +1,30 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 import java.time.LocalDateTime
 
+@Schema(
+  description = """A matcher for a date time attribute from the Prisoner record.
+  
+  For a between clause use both the min and max values.
+  
+  For < enter only the max value.
+  
+  For > enter only the min value.
+""",
+)
 data class DateTimeMatcher(
+  @Schema(description = "The attribute to search on", example = "currentIncentive.dateTime")
   override val attribute: String,
+  @Schema(description = "The minimum value to match", example = "2024-01-01T09:00:00Z")
   val minValue: LocalDateTime? = null,
+  @Schema(description = "The maximum value to match", example = "2024-01-31T21:00:00Z")
   val maxValue: LocalDateTime? = null,
 ) : TypeMatcher<LocalDateTime> {
+  @Schema(description = "Must be DateTime", example = "DateTime")
+  override val type: String = "DateTime"
+
   override fun validate() {
     if (minValue == null && maxValue == null) {
       throw AttributeSearchException("Attribute $attribute must have at least 1 min or max value")

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/IntMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/IntMatcher.kt
@@ -1,14 +1,35 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 
+@Schema(
+  description = """A matcher for an integer attribute from the Prisoner record.
+  
+  For a between clause use both min value and max value. By default the range is inclusive, but can be adjusted with minInclusive and maxInclusive.
+  
+  For <= enter only a max value, and for < set max inclusive to false.
+   
+  For >= enter only a min value, and for > set min inclusive to false.
+  
+  For equals enter the same integer in both the min value and max value and leave min/max inclusive as true.
+  """,
+)
 data class IntMatcher(
+  @Schema(description = "The attribute to match on", example = "heightCentimetres")
   override val attribute: String,
+  @Schema(description = "The minimum value to match on", example = "150")
   val minValue: Int? = null,
+  @Schema(description = "Whether the minimum value is inclusive", defaultValue = "true")
   val minInclusive: Boolean = true,
+  @Schema(description = "The maximum value to match on", example = "180")
   val maxValue: Int? = null,
+  @Schema(description = "Whether the maximum value is inclusive", defaultValue = "true")
   val maxInclusive: Boolean = true,
 ) : TypeMatcher<Int> {
+  @Schema(description = "Must be Int", example = "Int")
+  override val type: String = "Int"
+
   override fun validate() {
     if (minValue == null && maxValue == null) {
       throw AttributeSearchException("Attribute $attribute must have at least 1 min or max value")

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/Query.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/Query.kt
@@ -1,10 +1,15 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 
+@Schema(description = "A query to search for prisoners by attributes")
 data class Query(
+  @Schema(description = "The type of join to use when combining the matchers and subQueries", example = "AND")
   val joinType: JoinType,
+  @Schema(description = "Matchers that will be applied to this query")
   val matchers: List<TypeMatcher<*>>? = null,
+  @Schema(description = "A list of sub-queries of type Query that will be combined with the matchers in this query")
   val subQueries: List<Query>? = null,
 ) {
   fun validate() {
@@ -30,6 +35,7 @@ fun List<Query>.getAllTypeMatchers(): List<TypeMatcher<*>> =
     }
   }.toList()
 
+@Schema(description = "The type of join to use when combining the matchers and subQueries")
 enum class JoinType {
   AND,
   OR,

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/StringMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/StringMatcher.kt
@@ -1,12 +1,20 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
 
+import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 
+@Schema(description = "A matcher for a string attribute from the prisoner record")
 data class StringMatcher(
+  @Schema(description = "The attribute to match on", example = "aliases.lastName")
   override val attribute: String,
-  val condition: TextCondition,
+  @Schema(description = "The condition to apply to the attribute", example = "IS")
+  val condition: StringCondition,
+  @Schema(description = "The search term to apply to the attribute", example = "Smith")
   val searchTerm: String,
 ) : TypeMatcher<String> {
+  @Schema(description = "Must be String", example = "String")
+  override val type: String = "String"
+
   override fun validate() {
     if (searchTerm.isBlank()) {
       throw AttributeSearchException("Attribute $attribute must not have a blank search term")
@@ -14,7 +22,8 @@ data class StringMatcher(
   }
 }
 
-enum class TextCondition {
+@Schema(description = "The condition to apply to the attribute")
+enum class StringCondition {
   IS,
   IS_NOT,
   CONTAINS,

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/TypeMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/TypeMatcher.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KType
   JsonSubTypes.Type(value = StringMatcher::class, name = "String"),
 )
 sealed interface TypeMatcher<S> {
+  val type: String
   val attribute: String
   fun validate() {}
   fun genericType(): KClass<*> = this::class.genericType()

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResourceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResourceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.search.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.check
 import org.mockito.kotlin.verify
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -25,12 +26,11 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
       }
     """.trimIndent(),
   ) = """{
-    "queries": [
+    "query":
       {
         "joinType": "AND",
         "matchers": [$matchers]
       }
-    ]  
   }
   """.trimIndent()
 
@@ -195,8 +195,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as StringMatcher).searchTerm).isEqualTo("true")
+            assertThat((it.query.matchers?.first() as StringMatcher).searchTerm).isEqualTo("true")
           },
+          any(),
         )
       }
 
@@ -208,8 +209,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as StringMatcher).searchTerm).isEqualTo("$today")
+            assertThat((it.query.matchers?.first() as StringMatcher).searchTerm).isEqualTo("$today")
           },
+          any(),
         )
       }
 
@@ -221,8 +223,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as StringMatcher).searchTerm).isEqualTo("$now")
+            assertThat((it.query.matchers?.first() as StringMatcher).searchTerm).isEqualTo("$now")
           },
+          any(),
         )
       }
 
@@ -234,8 +237,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as StringMatcher).searchTerm).isEqualTo("1234")
+            assertThat((it.query.matchers?.first() as StringMatcher).searchTerm).isEqualTo("1234")
           },
+          any(),
         )
       }
     }
@@ -291,8 +295,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as BooleanMatcher).condition).isTrue()
+            assertThat((it.query.matchers?.first() as BooleanMatcher).condition).isTrue()
           },
+          any(),
         )
       }
 
@@ -322,8 +327,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as BooleanMatcher).condition).isTrue()
+            assertThat((it.query.matchers?.first() as BooleanMatcher).condition).isTrue()
           },
+          any(),
         )
       }
 
@@ -335,8 +341,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as BooleanMatcher).condition).isFalse()
+            assertThat((it.query.matchers?.first() as BooleanMatcher).condition).isFalse()
           },
+          any(),
         )
       }
 
@@ -414,8 +421,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as DateMatcher).minValue?.year).isEqualTo(1970)
+            assertThat((it.query.matchers?.first() as DateMatcher).minValue?.year).isEqualTo(1970)
           },
+          any(),
         )
       }
 
@@ -427,8 +435,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as DateMatcher).maxValue).isEqualTo(now.toLocalDate())
+            assertThat((it.query.matchers?.first() as DateMatcher).maxValue).isEqualTo(now.toLocalDate())
           },
+          any(),
         )
       }
 
@@ -626,8 +635,9 @@ class AttributeSearchResourceTest : AbstractSearchDataIntegrationTest() {
 
         verify(attributeSearchService).search(
           check {
-            assertThat((it.queries.first().matchers?.first() as IntMatcher).minValue).isEqualTo(140)
+            assertThat((it.query.matchers?.first() as IntMatcher).minValue).isEqualTo(140)
           },
+          any(),
         )
       }
 

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchServiceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchServiceTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesear
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.IntMatcher
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.JoinType
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.Query
+import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringCondition
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringMatcher
-import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.TextCondition
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -27,14 +27,12 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow subQueries with no contents`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            subQueries = listOf(
-              Query(JoinType.AND),
-            ),
-
+        Query(
+          JoinType.AND,
+          subQueries = listOf(
+            Query(JoinType.AND),
           ),
+
         ),
       )
 
@@ -48,15 +46,13 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow deep nested subQueries with no contents`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            subQueries = listOf(
-              Query(
-                JoinType.AND,
-                subQueries = listOf(
-                  Query(JoinType.AND),
-                ),
+        Query(
+          JoinType.AND,
+          subQueries = listOf(
+            Query(
+              JoinType.AND,
+              subQueries = listOf(
+                Query(JoinType.AND),
               ),
             ),
           ),
@@ -73,15 +69,13 @@ class AttributeSearchServiceTest {
     @Test
     fun `should validate attributes in nested matchers`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            subQueries = listOf(
-              Query(
-                JoinType.AND,
-                matchers = listOf(
-                  StringMatcher("firstName", TextCondition.IS, ""),
-                ),
+        Query(
+          JoinType.AND,
+          subQueries = listOf(
+            Query(
+              JoinType.AND,
+              matchers = listOf(
+                StringMatcher("firstName", StringCondition.IS, ""),
               ),
             ),
           ),
@@ -98,17 +92,15 @@ class AttributeSearchServiceTest {
     @Test
     fun `should validate attributes from a deep nested matcher`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            subQueries = listOf(
-              Query(
-                JoinType.AND,
-                subQueries = listOf(
-                  Query(
-                    JoinType.AND,
-                    matchers = listOf(StringMatcher("firstName", TextCondition.IS, "")),
-                  ),
+        Query(
+          JoinType.AND,
+          subQueries = listOf(
+            Query(
+              JoinType.AND,
+              subQueries = listOf(
+                Query(
+                  JoinType.AND,
+                  matchers = listOf(StringMatcher("firstName", StringCondition.IS, "")),
                 ),
               ),
             ),
@@ -129,12 +121,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should allow simple attribute`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("firstName", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("firstName", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -147,12 +137,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow unknown attributes`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("unknownAttribute", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("unknownAttribute", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -167,12 +155,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should allow attributes in lists of objects`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("aliases.firstName", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("aliases.firstName", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -185,12 +171,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow attributes from lists that don't exist`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("aliases.unknown", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("aliases.unknown", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -205,12 +189,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should allow attributes in nested objects`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("currentIncentive.level.code", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("currentIncentive.level.code", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -223,12 +205,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow attributes from nested objects that don't exist`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("currentIncentive.level.unknown", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("currentIncentive.level.unknown", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -246,12 +226,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow a String matcher for non-string attributes`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              StringMatcher("heightCentimetres", TextCondition.IS, "value"),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            StringMatcher("heightCentimetres", StringCondition.IS, "value"),
           ),
         ),
       )
@@ -266,12 +244,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow a Boolean matcher for non-boolean attributes`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              BooleanMatcher("firstName", true),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            BooleanMatcher(attribute = "firstName", condition = true),
           ),
         ),
       )
@@ -286,12 +262,10 @@ class AttributeSearchServiceTest {
     @Test
     fun `should not allow an Integer matcher for non-integer attributes`() {
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              IntMatcher("firstName", minValue = 150),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            IntMatcher("firstName", minValue = 150),
           ),
         ),
       )
@@ -307,12 +281,10 @@ class AttributeSearchServiceTest {
     fun `should not allow Date matcher for non-date attributes`() {
       val today = LocalDate.now()
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              DateMatcher("firstName", minValue = today),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            DateMatcher("firstName", minValue = today),
           ),
         ),
       )
@@ -328,12 +300,10 @@ class AttributeSearchServiceTest {
     fun `should not allow DateTime matcher for non-datetime attributes`() {
       val now = LocalDateTime.now()
       val request = AttributeSearchRequest(
-        listOf(
-          Query(
-            JoinType.AND,
-            matchers = listOf(
-              DateTimeMatcher("firstName", minValue = now.minusDays(7)),
-            ),
+        Query(
+          JoinType.AND,
+          matchers = listOf(
+            DateTimeMatcher("firstName", minValue = now.minusDays(7)),
           ),
         ),
       )

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/AttributeSearchRequestJsonTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/AttributeSearchRequestJsonTest.kt
@@ -13,8 +13,8 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesear
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.IntMatcher
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.JoinType
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.Query
+import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringCondition
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringMatcher
-import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.TextCondition
 import java.time.LocalDate
 
 @JsonTest
@@ -25,7 +25,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -37,22 +37,19 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
             ),
           ),
         ),
@@ -65,7 +62,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -83,27 +80,24 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              StringMatcher(
-                attribute = "lastName",
-                condition = TextCondition.IS,
-                searchTerm = "Smith",
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            StringMatcher(
+              attribute = "lastName",
+              condition = StringCondition.IS,
+              searchTerm = "Smith",
             ),
           ),
         ),
@@ -116,7 +110,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -147,37 +141,34 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
             ),
-            subQueries = listOf(
-              Query(
-                joinType = JoinType.OR,
-                matchers = listOf(
-                  StringMatcher(
-                    attribute = "lastName",
-                    condition = TextCondition.IS,
-                    searchTerm = "Smith",
-                  ),
-                  StringMatcher(
-                    attribute = "lastName",
-                    condition = TextCondition.IS,
-                    searchTerm = "Jones",
-                  ),
+          ),
+          subQueries = listOf(
+            Query(
+              joinType = JoinType.OR,
+              matchers = listOf(
+                StringMatcher(
+                  attribute = "lastName",
+                  condition = StringCondition.IS,
+                  searchTerm = "Smith",
+                ),
+                StringMatcher(
+                  attribute = "lastName",
+                  condition = StringCondition.IS,
+                  searchTerm = "Jones",
                 ),
               ),
             ),
@@ -192,7 +183,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "OR",
               "subQueries": [
@@ -232,45 +223,42 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.OR,
-            subQueries = listOf(
-              Query(
-                joinType = JoinType.AND,
-                matchers = listOf(
-                  StringMatcher(
-                    attribute = "firstName",
-                    condition = TextCondition.IS,
-                    searchTerm = "John",
-                  ),
-                  StringMatcher(
-                    attribute = "lastName",
-                    condition = TextCondition.IS,
-                    searchTerm = "Smith",
-                  ),
+        query = Query(
+          joinType = JoinType.OR,
+          subQueries = listOf(
+            Query(
+              joinType = JoinType.AND,
+              matchers = listOf(
+                StringMatcher(
+                  attribute = "firstName",
+                  condition = StringCondition.IS,
+                  searchTerm = "John",
+                ),
+                StringMatcher(
+                  attribute = "lastName",
+                  condition = StringCondition.IS,
+                  searchTerm = "Smith",
                 ),
               ),
-              Query(
-                joinType = JoinType.AND,
-                matchers = listOf(
-                  StringMatcher(
-                    attribute = "firstName",
-                    condition = TextCondition.IS,
-                    searchTerm = "Jack",
-                  ),
-                  StringMatcher(
-                    attribute = "lastName",
-                    condition = TextCondition.IS_NOT,
-                    searchTerm = "Jones",
-                  ),
+            ),
+            Query(
+              joinType = JoinType.AND,
+              matchers = listOf(
+                StringMatcher(
+                  attribute = "firstName",
+                  condition = StringCondition.IS,
+                  searchTerm = "Jack",
+                ),
+                StringMatcher(
+                  attribute = "lastName",
+                  condition = StringCondition.IS_NOT,
+                  searchTerm = "Jones",
                 ),
               ),
             ),
@@ -285,7 +273,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -302,26 +290,23 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              BooleanMatcher(
-                attribute = "recall",
-                condition = true,
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            BooleanMatcher(
+              attribute = "recall",
+              condition = true,
             ),
           ),
         ),
@@ -334,7 +319,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -351,27 +336,24 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              IntMatcher(
-                attribute = "heightCentimetres",
-                minValue = 150,
-                minInclusive = true,
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            IntMatcher(
+              attribute = "heightCentimetres",
+              minValue = 150,
+              minInclusive = true,
             ),
           ),
         ),
@@ -384,7 +366,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -402,29 +384,26 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
        }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              IntMatcher(
-                attribute = "shoeSize",
-                minValue = 11,
-                minInclusive = true,
-                maxValue = 12,
-                maxInclusive = true,
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            IntMatcher(
+              attribute = "shoeSize",
+              minValue = 11,
+              minInclusive = true,
+              maxValue = 12,
+              maxInclusive = true,
             ),
           ),
         ),
@@ -437,7 +416,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -460,31 +439,28 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
         }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              DateMatcher(
-                attribute = "receptionDate",
-                minValue = LocalDate.parse("2023-01-01"),
-              ),
-              DateMatcher(
-                attribute = "releaseDate",
-                maxValue = LocalDate.parse("2024-01-01"),
-                maxInclusive = false,
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            DateMatcher(
+              attribute = "receptionDate",
+              minValue = LocalDate.parse("2023-01-01"),
+            ),
+            DateMatcher(
+              attribute = "releaseDate",
+              maxValue = LocalDate.parse("2024-01-01"),
+              maxInclusive = false,
             ),
           ),
         ),
@@ -497,7 +473,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -514,26 +490,23 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
        }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              DateTimeMatcher(
-                attribute = "currentIncentive.dateTime",
-                minValue = LocalDate.parse("2023-01-01").atStartOfDay(),
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            DateTimeMatcher(
+              attribute = "currentIncentive.dateTime",
+              minValue = LocalDate.parse("2023-01-01").atStartOfDay(),
             ),
           ),
         ),
@@ -546,7 +519,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -564,29 +537,26 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
        }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              DateMatcher(
-                attribute = "receptionDate",
-                minValue = LocalDate.parse("2023-01-01"),
-                minInclusive = true,
-                maxValue = LocalDate.parse("2023-01-01"),
-                maxInclusive = true,
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            DateMatcher(
+              attribute = "receptionDate",
+              minValue = LocalDate.parse("2023-01-01"),
+              minInclusive = true,
+              maxValue = LocalDate.parse("2023-01-01"),
+              maxInclusive = true,
             ),
           ),
         ),
@@ -599,7 +569,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -623,32 +593,29 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
        }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
-              StringMatcher(
-                attribute = "tattoos.bodyPart",
-                condition = TextCondition.IS,
-                searchTerm = "shoulder",
-              ),
-              StringMatcher(
-                attribute = "tattoos.comment",
-                condition = TextCondition.CONTAINS,
-                searchTerm = "dragon",
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
+            ),
+            StringMatcher(
+              attribute = "tattoos.bodyPart",
+              condition = StringCondition.IS,
+              searchTerm = "shoulder",
+            ),
+            StringMatcher(
+              attribute = "tattoos.comment",
+              condition = StringCondition.CONTAINS,
+              searchTerm = "dragon",
             ),
           ),
         ),
@@ -661,7 +628,7 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
     val request = objectMapper.readValue<AttributeSearchRequest>(
       """
         {
-          "queries": [
+          "query":
             {
               "joinType": "AND",
               "matchers": [
@@ -692,37 +659,34 @@ class AttributeSearchRequestJsonTest(@Autowired val objectMapper: ObjectMapper) 
                 }
               ]
             }
-          ]
        }
       """.trimIndent(),
     )
 
     assertThat(request).isEqualTo(
       AttributeSearchRequest(
-        queries = listOf(
-          Query(
-            joinType = JoinType.AND,
-            matchers = listOf(
-              StringMatcher(
-                attribute = "firstName",
-                condition = TextCondition.IS,
-                searchTerm = "John",
-              ),
+        query = Query(
+          joinType = JoinType.AND,
+          matchers = listOf(
+            StringMatcher(
+              attribute = "firstName",
+              condition = StringCondition.IS,
+              searchTerm = "John",
             ),
-            subQueries = listOf(
-              Query(
-                joinType = JoinType.OR,
-                matchers = listOf(
-                  StringMatcher(
-                    attribute = "scars.bodyPart",
-                    condition = TextCondition.IS,
-                    searchTerm = "face",
-                  ),
-                  StringMatcher(
-                    attribute = "scars.bodyPart",
-                    condition = TextCondition.IS,
-                    searchTerm = "head",
-                  ),
+          ),
+          subQueries = listOf(
+            Query(
+              joinType = JoinType.OR,
+              matchers = listOf(
+                StringMatcher(
+                  attribute = "scars.bodyPart",
+                  condition = StringCondition.IS,
+                  searchTerm = "face",
+                ),
+                StringMatcher(
+                  attribute = "scars.bodyPart",
+                  condition = StringCondition.IS,
+                  searchTerm = "head",
                 ),
               ),
             ),

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/AttributeSearchRequestTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/AttributeSearchRequestTest.kt
@@ -7,24 +7,14 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesear
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.AttributeSearchRequest
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.JoinType
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.Query
+import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringCondition
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringMatcher
-import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.TextCondition
 
 class AttributeSearchRequestTest {
-  @Test
-  fun `should not allow zero queries`() {
-    val request = AttributeSearchRequest(emptyList())
-
-    assertThrows<AttributeSearchException> {
-      request.validate(emptyMap())
-    }.also {
-      assertThat(it.message).contains("one matcher")
-    }
-  }
 
   @Test
   fun `should validate queries`() {
-    val request = AttributeSearchRequest(listOf(Query(JoinType.AND)))
+    val request = AttributeSearchRequest(Query(JoinType.AND))
 
     assertThrows<AttributeSearchException> {
       request.validate(emptyMap())
@@ -36,11 +26,9 @@ class AttributeSearchRequestTest {
   @Test
   fun `should validate type matchers`() {
     val request = AttributeSearchRequest(
-      listOf(
-        Query(
-          JoinType.AND,
-          matchers = listOf(StringMatcher("missingAttribute", TextCondition.IS, "value")),
-        ),
+      Query(
+        JoinType.AND,
+        matchers = listOf(StringMatcher("missingAttribute", StringCondition.IS, "value")),
       ),
     )
 

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/StringMatcherTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/dto/StringMatcherTest.kt
@@ -4,13 +4,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
+import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringCondition
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.StringMatcher
-import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api.TextCondition
 
 class StringMatcherTest {
   @Test
   fun `should not allow blank value`() {
-    val matcher = StringMatcher("firstName", TextCondition.IS, "")
+    val matcher = StringMatcher("firstName", StringCondition.IS, "")
 
     assertThrows<AttributeSearchException> {
       matcher.validate()


### PR DESCRIPTION
![image](https://github.com/ministryofjustice/hmpps-prisoner-search/assets/58170926/6431af35-3364-4f20-bcf3-7606112e97e2)
![image](https://github.com/ministryofjustice/hmpps-prisoner-search/assets/58170926/c7c9ea53-1977-44ee-a639-d5b71a49ce83)
![image](https://github.com/ministryofjustice/hmpps-prisoner-search/assets/58170926/a2f61747-8dbc-48af-98cc-308b25149f48)
![image](https://github.com/ministryofjustice/hmpps-prisoner-search/assets/58170926/f14fedea-0937-4185-80b3-0726eb32d9a4)
![image](https://github.com/ministryofjustice/hmpps-prisoner-search/assets/58170926/e4ca6bd6-84f7-415f-9291-da287089a562)

The example above has the old `queries` list - I've changed that with another commit but can't be bothered with more screen shots.