### PR TITLE
SDIT-1336 Go back to old api URL properties - it's established and it works fine

### DIFF
--- a/hmpps-prisoner-search/helm_deploy/values-dev.yaml
+++ b/hmpps-prisoner-search/helm_deploy/values-dev.yaml
@@ -8,8 +8,8 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
-    HMPPS_AUTH_BASE_URI: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    PRISON_API_BASE_URI: "https://prison-api-dev.prison.service.justice.gov.uk"
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    API_BASE_URL_PRISON_API: "https://prison-api-dev.prison.service.justice.gov.uk"
 
   scheduledDowntime:
     enabled: true

--- a/hmpps-prisoner-search/helm_deploy/values-preprod.yaml
+++ b/hmpps-prisoner-search/helm_deploy/values-preprod.yaml
@@ -6,8 +6,8 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
-    HMPPS_AUTH_BASE_URI: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    PRISON_API_BASE_URI: "https://prison-api-preprod.prison.service.justice.gov.uk"
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    API_BASE_URL_PRISON_API: "https://prison-api-preprod.prison.service.justice.gov.uk"
 
   # Additional allowlist rules
   # See also allowlist values helm_deploy/prisoner-offender-search/values.yaml

--- a/hmpps-prisoner-search/helm_deploy/values-prod.yaml
+++ b/hmpps-prisoner-search/helm_deploy/values-prod.yaml
@@ -10,5 +10,5 @@ generic-service:
     prum-prod-platform-3: 18.170.155.82/32
 
   env:
-    HMPPS_AUTH_BASE_URI: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    PRISON_API_BASE_URI: "https://api.prison.service.justice.gov.uk"
+    API_BASE_URL_HMPPS_AUTH: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    API_BASE_URL_PRISON_API: "https://api.prison.service.justice.gov.uk"

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/config/WebClientConfiguration.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/config/WebClientConfiguration.kt
@@ -11,8 +11,8 @@ import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${prison-api.base-uri}") val prisonApiBaseUri: String,
-  @Value("\${hmpps-auth.base-uri}") val hmppsAuthBaseUri: String,
+  @Value("\${api.base.url.prison-api}") val prisonApiBaseUri: String,
+  @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:20s}") val timeout: Duration,
 ) {

--- a/hmpps-prisoner-search/src/main/resources/application-dev.yml
+++ b/hmpps-prisoner-search/src/main/resources/application-dev.yml
@@ -1,10 +1,9 @@
 server:
   shutdown: immediate
 
-hmpps-auth:
-  base-uri: http://localhost:8090/auth
-prison-api:
-  base-uri: http://localhost:8093
+api.base.url:
+  hmpps-auth: http://localhost:8090/auth
+  prison-api: http://localhost:8093
 
 opensearch:
   uris: http://os01.eu-west-2.opensearch.localhost.localstack.cloud:4566

--- a/hmpps-prisoner-search/src/main/resources/application.yml
+++ b/hmpps-prisoner-search/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${hmpps-auth.base-uri}/.well-known/jwks.json
+          jwk-set-uri: ${api.base.url.hmpps-auth}/.well-known/jwks.json
 
       client:
         registration:
@@ -32,7 +32,7 @@ spring:
             scope: read
         provider:
           hmpps-auth:
-            token-uri: ${hmpps-auth.base-uri}/oauth/token
+            token-uri: ${api.base.url.hmpps-auth}/oauth/token
 
   profiles:
     group:

--- a/hmpps-prisoner-search/src/test/resources/application-test.yml
+++ b/hmpps-prisoner-search/src/test/resources/application-test.yml
@@ -5,10 +5,9 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
-hmpps-auth:
-  base-uri: http://localhost:8090/auth
-prison-api:
-  base-uri: http://localhost:8093
+api.base.url:
+  hmpps-auth: http://localhost:8090/auth
+  prison-api: http://localhost:8093
 
 opensearch:
   uris: http://os01.eu-west-2.opensearch.localhost.localstack.cloud:4566


### PR DESCRIPTION
And it means you can do things like [this](https://github.com/ministryofjustice/hmpps-prisoner-to-nomis-update/blob/main/helm_deploy/values-prod.yaml#L12) and [this](https://github.com/ministryofjustice/hmpps-prisoner-to-nomis-update/blob/main/src/test/resources/application-test.yml#L8). Which are easier to digest.