### PR TITLE
SDIT-1561 Fix bug with times on zero seconds

### DIFF
--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcher.kt
@@ -5,6 +5,7 @@ import org.opensearch.index.query.AbstractQueryBuilder
 import org.opensearch.index.query.QueryBuilders
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.AttributeSearchException
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit.SECONDS
 
 @Schema(
@@ -41,8 +42,8 @@ data class DateTimeMatcher(
   }
 
   override fun buildQuery(): AbstractQueryBuilder<*> {
-    val min = minValue?.truncatedTo(SECONDS)?.toString()
-    val max = maxValue?.truncatedTo(SECONDS)?.toString()
+    val min = minValue?.truncateToSeconds()
+    val max = maxValue?.truncateToSeconds()
     return when {
       min != null && max != null -> {
         QueryBuilders.rangeQuery(attribute).from(min).to(max)
@@ -56,6 +57,9 @@ data class DateTimeMatcher(
       else -> throw AttributeSearchException("Attribute $attribute must have at least 1 min or max value")
     }
   }
+
+  private fun LocalDateTime.truncateToSeconds() =
+    truncatedTo(SECONDS).format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
   override fun toString(): String {
     val min = minValue?.let { "$attribute > $minValue" } ?: ""

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcherTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/DateTimeMatcherTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.search.services.attributesearch.api
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.opensearch.index.query.RangeQueryBuilder
+import java.time.LocalDateTime
+
+class DateTimeMatcherTest {
+  @Test
+  fun `should not truncate seconds if they are 00`() {
+    val dateTimeMatcher = DateTimeMatcher(
+      attribute = "currentIncentive.dateTime",
+      minValue = LocalDateTime.parse("2024-01-01T09:00:00"),
+      maxValue = LocalDateTime.parse("2024-01-31T21:00:00.123"),
+    )
+
+    val query = dateTimeMatcher.buildQuery() as RangeQueryBuilder
+
+    assertThat(query.from()).isEqualTo("2024-01-01T09:00:00")
+    assertThat(query.to()).isEqualTo("2024-01-31T21:00:00")
+  }
+}


### PR DESCRIPTION
DateTimeMatcher tests intermittently failed when the time had zero seconds because it was being truncated as per the LocalDateTime.toString() Javadocs:
```
 The output will be one of the following ISO-8601 formats:

    uuuu-MM-dd'T'HH:mm
    uuuu-MM-dd'T'HH:mm:ss
    uuuu-MM-dd'T'HH:mm:ss.SSS
    uuuu-MM-dd'T'HH:mm:ss.SSSSSS
    uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSS

The format used will be the shortest that outputs the full value of the time where the omitted parts are implied to be zero.
```