### PR TITLE
SDIT-1561 Remove otherMarks from the Prisoner record

### DIFF
--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
@@ -391,28 +391,22 @@ open class Prisoner : Diffable<Prisoner> {
   var shoeSize: Int? = null
 
   @Schema(
-    description = "List of parts of the body that have tattoos. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
+    description = "List of parts of the body that have tattoos. This includes marks and other marks whose comment contains 'tattoo'. 'From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
   )
   @DiffableProperty(DiffCategory.PHYSICAL_DETAILS)
   var tattoos: List<BodyPartDetail>? = null
 
   @Schema(
-    description = "List of parts of the body that have scars. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
+    description = "List of parts of the body that have scars. This includes marks and other marks whose comment contains 'scar'. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
   )
   @DiffableProperty(DiffCategory.PHYSICAL_DETAILS)
   var scars: List<BodyPartDetail>? = null
 
   @Schema(
-    description = "List of parts of the body that have marks. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
+    description = "List of parts of the body that have marks. This includes NOMIS physical details of type 'marks' and 'otherMarks'. If we find a comment with either 'tattoo' or 'scar' we also add to the list of tattoos or scars. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
   )
   @DiffableProperty(DiffCategory.PHYSICAL_DETAILS)
   var marks: List<BodyPartDetail>? = null
-
-  @Schema(
-    description = "List of parts of the body that have other marks. From REFERENCE_CODES table where DOMAIN = BODY_PART. Allowable values extracted 08/02/2023.",
-  )
-  @DiffableProperty(DiffCategory.PHYSICAL_DETAILS)
-  var otherMarks: List<BodyPartDetail>? = null
 
   override fun diff(other: Prisoner): DiffResult<Prisoner> = getDiffResult(this, other)
 

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
@@ -67,8 +67,11 @@ fun Prisoner.translate(existingPrisoner: Prisoner? = null, ob: OffenderBooking, 
       when (pm.type) {
         "Tattoo" -> this.tattoos = this.tattoos?.plus(bodyPart) ?: listOf(bodyPart)
         "Scar" -> this.scars = this.scars?.plus(bodyPart) ?: listOf(bodyPart)
-        "Mark" -> this.marks = this.marks?.plus(bodyPart) ?: listOf(bodyPart)
-        "Other" -> this.otherMarks = this.otherMarks?.plus(bodyPart) ?: listOf(bodyPart)
+        "Mark", "Other" -> {
+          this.marks = this.marks?.plus(bodyPart) ?: listOf(bodyPart)
+          this.tattoos = this.tattoos.addIfContains(bodyPart, "tattoo")
+          this.scars = this.scars.addIfContains(bodyPart, "scar")
+        }
       }
     }
   }
@@ -148,3 +151,12 @@ private fun IncentiveLevel?.toCurrentIncentive(): CurrentIncentive? = this?.let 
     dateTime = it.iepTime.withNano(0),
   )
 }
+
+private fun List<BodyPartDetail>?.addIfContains(bodyPart: BodyPartDetail, keyword: String): List<BodyPartDetail>? =
+  if (bodyPart.comment?.lowercase()?.contains(keyword) == true) {
+    bodyPart.copy().let {
+      this?.plus(it) ?: listOf(it)
+    }
+  } else {
+    this
+  }

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/TranslatorTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/TranslatorTest.kt
@@ -501,9 +501,42 @@ class TranslatorTest {
       restrictedPatientData = Result.success(null),
     )
     assertThat(prisoner.tattoos).containsExactly(BodyPartDetail("Elbow", "Comment here"), BodyPartDetail("Foot", null))
-    assertThat(prisoner.marks).containsExactly(BodyPartDetail("Ear", "Some comment"))
+    assertThat(prisoner.marks).containsExactly(BodyPartDetail("Ear", "Some comment"), BodyPartDetail("Arm", null))
     assertThat(prisoner.scars).containsExactly(BodyPartDetail("Torso", null))
-    assertThat(prisoner.otherMarks).containsExactly(BodyPartDetail("Arm", null))
+  }
+
+  @Test
+  internal fun `Physical Marks adds tattoos and scars from marks or other marks`() {
+    val prisoner = Prisoner().translate(
+      ob = aBooking().copy(
+        physicalMarks = listOf(
+          PhysicalMark("Tattoo", "Left", "Elbow", "Upper", "Comment here", null),
+          PhysicalMark("Scar", null, "Torso", null, null, null),
+          PhysicalMark("Mark", null, "Arm", null, "Mark tattoo", null),
+          PhysicalMark("Mark", null, "Shoulder", null, "Mark scar", null),
+          PhysicalMark("Other", "Centre", "Head", null, "Other mark TATTOO", null),
+          PhysicalMark("Other", "Centre", "Hand", null, "Other mark SCAR", null),
+        ),
+      ),
+      incentiveLevel = Result.success(null),
+      restrictedPatientData = Result.success(null),
+    )
+    assertThat(prisoner.tattoos).containsExactlyInAnyOrder(
+      BodyPartDetail("Elbow", "Comment here"),
+      BodyPartDetail("Arm", "Mark tattoo"),
+      BodyPartDetail("Head", "Other mark TATTOO"),
+    )
+    assertThat(prisoner.scars).containsExactlyInAnyOrder(
+      BodyPartDetail("Torso", null),
+      BodyPartDetail("Shoulder", "Mark scar"),
+      BodyPartDetail("Hand", "Other mark SCAR"),
+    )
+    assertThat(prisoner.marks).containsExactlyInAnyOrder(
+      BodyPartDetail("Arm", "Mark tattoo"),
+      BodyPartDetail("Head", "Other mark TATTOO"),
+      BodyPartDetail("Shoulder", "Mark scar"),
+      BodyPartDetail("Hand", "Other mark SCAR"),
+    )
   }
 }
 

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PhysicalDetailService.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PhysicalDetailService.kt
@@ -172,14 +172,6 @@ class PhysicalDetailService(
           detailQuery.shouldOrMust(lenient, QueryBuilders.matchPhraseQuery("marks.comment", mark.comment))
         }
       }
-      otherMarks?.forEach { other ->
-        other.bodyPart?.let {
-          detailQuery.shouldOrMust(lenient, QueryBuilders.matchPhraseQuery("otherMarks.bodyPart", other.bodyPart))
-        }
-        other.comment?.let {
-          detailQuery.shouldOrMust(lenient, QueryBuilders.matchPhraseQuery("otherMarks.comment", other.comment))
-        }
-      }
     }
 
     return detailQuery

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/ReferenceDataService.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/ReferenceDataService.kt
@@ -85,7 +85,6 @@ enum class ReferenceDataAttribute(keyword: Boolean = true, field: String? = null
   marksBodyPart(field = "marks.bodyPart.keyword"),
   maritalStatus,
   nationality,
-  otherMarksBodyPart(field = "otherMarks.bodyPart.keyword"),
   religion,
   rightEyeColour,
   scarsBodyPart(field = "scars.bodyPart.keyword"),

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PhysicalDetailRequest.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PhysicalDetailRequest.kt
@@ -127,11 +127,6 @@ data class PhysicalDetailRequest(
   val scars: List<BodyPart>? = null,
 
   @Schema(
-    description = "List of body parts that have a different mark",
-  )
-  val otherMarks: List<BodyPart>? = null,
-
-  @Schema(
     description = """
         Whether all terms are required to match. If set to true then only matches on all fields will return a result.
         If set to false then matches will return a higher score than non matches, but all will be returned.

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/model/ObjectBuilder.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/model/ObjectBuilder.kt
@@ -56,7 +56,6 @@ data class PhysicalCharacteristicBuilder(
 
 data class PhysicalMarkBuilder(
   val mark: List<BodyPartBuilder>? = null,
-  val other: List<BodyPartBuilder>? = null,
   val scar: List<BodyPartBuilder>? = null,
   val tattoo: List<BodyPartBuilder>? = null,
 )
@@ -193,9 +192,6 @@ fun PrisonerBuilder.toOffenderBooking(): OffenderBooking =
       }
       this.physicalMarks?.mark?.forEach {
         pms.add(PhysicalMark("Mark", null, it.bodyPart, null, it.comment, null))
-      }
-      this.physicalMarks?.other?.forEach {
-        pms.add(PhysicalMark("Other", null, it.bodyPart, null, it.comment, null))
       }
       this.physicalMarks?.scar?.forEach {
         pms.add(PhysicalMark("Scar", null, it.bodyPart, null, it.comment, null))

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/model/nomis/dto/translator.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/model/nomis/dto/translator.kt
@@ -66,8 +66,7 @@ fun Prisoner.translate(existingPrisoner: Prisoner?, ob: OffenderBooking, incenti
       when (pm.type) {
         "Tattoo" -> this.tattoos = this.tattoos?.plus(bodyPart) ?: listOf(bodyPart)
         "Scar" -> this.scars = this.scars?.plus(bodyPart) ?: listOf(bodyPart)
-        "Mark" -> this.marks = this.marks?.plus(bodyPart) ?: listOf(bodyPart)
-        "Other" -> this.otherMarks = this.otherMarks?.plus(bodyPart) ?: listOf(bodyPart)
+        "Mark", "Other" -> this.marks = this.marks?.plus(bodyPart) ?: listOf(bodyPart)
       }
     }
   }

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PhysicalDetailResourceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PhysicalDetailResourceTest.kt
@@ -73,7 +73,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "rose"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -95,7 +94,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Finger", "rose"), BodyPartBuilder("Foot")),
           scar = listOf(BodyPartBuilder("Ankle", "nasty looking scar"), BodyPartBuilder("Knee")),
-          other = listOf(BodyPartBuilder("Nose", "bent to the right")),
           mark = listOf(BodyPartBuilder("Torso", "birthmark on chest")),
         ),
       ),
@@ -116,7 +114,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "rose"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -139,7 +136,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "dragon"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -161,7 +157,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Knee", "dragon"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -737,47 +732,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
         listOf(mapOf("bodyPart" to "Lip", "comment" to "too much")),
       )
     }
-
-    @Test
-    fun `searching by otherMarks with a body part`(): Unit = physicalDetailSearch(
-      detailRequest = PhysicalDetailRequest(
-        otherMarks = listOf(BodyPart("Head")),
-        prisonIds = listOf("AGI", "LEI"),
-      ),
-      expectedPrisoners = listOf("G7089EZ", "G7090AD", "G7090BA", "G7090BC"),
-    )
-
-    @Test
-    fun `searching by otherMarks with a body part and a comment`(): Unit = physicalDetailSearch(
-      detailRequest = PhysicalDetailRequest(
-        otherMarks = listOf(BodyPart(bodyPart = "Head", comment = "left ear")),
-        prisonIds = listOf("AGI", "LEI"),
-      ),
-      expectedPrisoners = listOf("G7089EZ", "G7090AD", "G7090BA", "G7090BC"),
-    )
-
-    @Test
-    fun `searching by otherMarks with a comment`(): Unit = physicalDetailSearch(
-      detailRequest = PhysicalDetailRequest(
-        otherMarks = listOf(BodyPart(comment = "left ear")),
-        prisonIds = listOf("AGI", "LEI"),
-      ),
-      expectedPrisoners = listOf("G7089EZ", "G7090AD", "G7090BA", "G7090BC"),
-    )
-
-    @Test
-    fun `otherMarks are returned in search results`(): Unit = physicalDetailSearch(
-      detailRequest = PhysicalDetailRequest(
-        ethnicity = "White: Any other background",
-        prisonIds = listOf("AGI", "LEI"),
-      ),
-      expectedPrisoners = listOf("G7090AC", "G7090BA"),
-    ) {
-      assertThat(it).extracting("otherMarks").containsExactly(
-        listOf(mapOf("bodyPart" to "Nose", "comment" to "bent to the right")),
-        listOf(mapOf("bodyPart" to "Head", "comment" to "left ear missing")),
-      )
-    }
   }
 
   @Test
@@ -801,7 +755,6 @@ class PhysicalDetailResourceTest : AbstractSearchIntegrationTest() {
       build = "february",
       tattoos = listOf(BodyPart(bodyPart = "february")),
       scars = listOf(BodyPart(bodyPart = "february")),
-      otherMarks = listOf(BodyPart(bodyPart = "february")),
       marks = listOf(BodyPart(bodyPart = "february")),
     ),
     expectedPrisoners = listOf("H7089EY", "H7089EZ", "H7090BA", "H7090BB", "H1090AA", "G7090BC", "G7089EZ", "G7090AC", "G7090AD", "G7090BA"),

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/ReferenceDataResourceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/ReferenceDataResourceTest.kt
@@ -36,7 +36,6 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceData
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.maritalStatus
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.marksBodyPart
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.nationality
-import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.otherMarksBodyPart
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.religion
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.rightEyeColour
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.ReferenceDataAttribute.scarsBodyPart
@@ -68,7 +67,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "rose"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
         profileInformation = ProfileInformationBuilder(
@@ -99,7 +97,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Finger", "rose"), BodyPartBuilder("Foot")),
           scar = listOf(BodyPartBuilder("Toe", "nasty looking scar"), BodyPartBuilder("Knee")),
-          other = listOf(BodyPartBuilder("Nose", "bent to the right")),
           mark = listOf(BodyPartBuilder("Torso", "birthmark on chest")),
         ),
         profileInformation = ProfileInformationBuilder(
@@ -128,7 +125,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "rose"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -151,7 +147,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Ankle", "dragon"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -173,7 +168,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
         physicalMarks = PhysicalMarkBuilder(
           tattoo = listOf(BodyPartBuilder("Knee", "dragon"), BodyPartBuilder("Knee")),
           scar = listOf(BodyPartBuilder("Finger"), BodyPartBuilder("Foot")),
-          other = listOf(BodyPartBuilder("Head", "left ear missing")),
           mark = listOf(BodyPartBuilder("Lip", "too much")),
         ),
       ),
@@ -242,7 +236,6 @@ class ReferenceDataResourceTest : AbstractSearchIntegrationTest() {
       arguments(marksBodyPart, listOf("Lip", "Torso"), null),
       arguments(maritalStatus, listOf("Married", "Single-not married/in civil partnership"), null),
       arguments(nationality, listOf("British", "Irish"), null),
-      arguments(otherMarksBodyPart, listOf("Head", "Nose"), null),
       arguments(religion, listOf("Agnostic", "Jedi Knight"), null),
       arguments(rightEyeColour, listOf("Clouded", "Green", "Missing"), null),
       arguments(scarsBodyPart, listOf("Finger", "Foot", "Knee", "Toe"), null),

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchFieldsIntegrationTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchFieldsIntegrationTest.kt
@@ -108,12 +108,6 @@ class AttributeSearchFieldsIntegrationTest : AbstractSearchIntegrationTest() {
         comment = "Tribal tattoo",
       ),
     )
-    otherMarks = listOf(
-      BodyPartDetail(
-        bodyPart = "Right Arm",
-        comment = "Burn scar",
-      ),
-    )
     additionalDaysAwarded = 10
     heightCentimetres = 180
     weightKilograms = 88
@@ -205,8 +199,6 @@ class AttributeSearchFieldsIntegrationTest : AbstractSearchIntegrationTest() {
     "scars.comment,Scar on left cheek",
     "marks.bodyPart,Left Arm",
     "marks.comment,Tribal tattoo",
-    "otherMarks.bodyPart,Right Arm",
-    "otherMarks.comment,Burn scar",
   )
   fun `string fields`(field: String, value: String) {
     val request = RequestDsl {


### PR DESCRIPTION
In NOMIS there appears to be no quantifiable difference between `marks` and `otherMarks` - but leaving them separate means they have to be searched for individually. Instead we will delete `otherMarks` and consolidate them into `marks`. It should be safe to delete `otherMarks` because a) it's nullable and b) no clients are referencing the field anyway (except in test JSON).

We've also noticed that there are a lot of comments in `marks` and `otherMarks` which include either "tattoo" or "scar" but both NOMIS and prisoner search have dedicated storage for `tattoos` and `scars`. This makes it hard to search for a tattoo or a scar - you'd need to check marks too. To make the search easier we've decided to copy any marks with comments including "tattoo" or "scar" into the relevant prisoner search field. Note that they will still be included in the marks field so we don't lose any info.