### PR TITLE
SDIT-1561 Don't perform fuzzy query for wildcards

### DIFF
--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/StringMatcher.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/api/StringMatcher.kt
@@ -42,7 +42,7 @@ data class StringMatcher(
               .should(query)
               .should(QueryBuilders.fuzzyQuery(attr.openSearchName, searchTerm))
           }
-          attr.isFuzzy && condition == CONTAINS -> {
+          attr.isFuzzy && condition == CONTAINS && !searchTerm.hasWildcard() -> {
             QueryBuilders.boolQuery()
               .should(query)
               .should(QueryBuilders.matchQuery(attribute, searchTerm).fuzziness(Fuzziness.AUTO))
@@ -50,6 +50,8 @@ data class StringMatcher(
           else -> query
         }
       } ?: throw AttributeSearchException("Attribute $attribute not recognised")
+
+  private fun String.hasWildcard() = contains("?") || contains("*")
 
   override fun toString(): String {
     val condition = when (condition) {

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchIntegrationTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchIntegrationTest.kt
@@ -677,6 +677,19 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
 
       webTestClient.attributeSearch(request).expectPrisoners("P2")
     }
+
+    @Test
+    fun `shouldn't perform a fuzzy search if wildcards used`() {
+      val request = RequestDsl {
+        query {
+          stringMatcher("marks.bodyPart" IS "Arm")
+          stringMatcher("marks.comment" CONTAINS "birthmark*wrist")
+        }
+      }
+
+      // Shouldn't find P1 who has Arm/birthmark because the * should preclude a fuzzy search
+      webTestClient.attributeSearch(request).expectPrisoners("P2")
+    }
   }
 
   @Nested


### PR DESCRIPTION
Otherwise the fuzzy query will find partial matches on the search term but we want a full match