### PR TITLE
SDIT-1583 Switch to the model returned by the new prison-api endpoint

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
@@ -108,14 +108,12 @@ fun Prisoner.translate(existingPrisoner: Prisoner? = null, ob: OffenderBooking, 
     ob.sentenceDetail?.conditionalReleaseOverrideDate ?: ob.sentenceDetail?.conditionalReleaseDate
   this.actualParoleDate = ob.sentenceDetail?.actualParoleDate
 
-  // get the most serious offence for this booking
-  this.mostSeriousOffence =
-    ob.offenceHistory?.firstOrNull { off -> off.mostSerious && off.bookingId == ob.bookingId }?.offenceDescription
+  this.mostSeriousOffence = ob.mostSeriousOffence
   this.recall = ob.recall
   this.legalStatus = ob.legalStatus
   this.imprisonmentStatus = ob.imprisonmentStatus
   this.imprisonmentStatusDescription = ob.imprisonmentStatusDescription
-  this.indeterminateSentence = ob.sentenceTerms?.any { st -> st.lifeSentence && st.bookingId == ob.bookingId }
+  this.indeterminateSentence = ob.indeterminateSentence
 
   restrictedPatientData.onSuccess { rp ->
     this.restrictedPatient = rp != null

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NomisService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NomisService.kt
@@ -7,6 +7,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClientRequest
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.dto.nomis.OffenderBooking
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.dto.nomis.OffenderBookingOld
 import java.time.Duration
 
 @Service
@@ -42,6 +43,14 @@ class NomisService(
 
   fun getOffender(offenderNo: String): OffenderBooking? = prisonApiWebClient.get()
     .uri("/api/offenders/{offenderNo}", offenderNo)
+    .retrieve()
+    .bodyToMono(OffenderBookingOld::class.java)
+    .onErrorResume(NotFound::class.java) { Mono.empty() }
+    .block()
+    ?.toOffenderBooking()
+
+  fun getOffenderNewEndpoint(offenderNo: String): OffenderBooking? = prisonApiWebClient.get()
+    .uri("/api/prisoner-search/offenders/{offenderNo}", offenderNo)
     .retrieve()
     .bodyToMono(OffenderBooking::class.java)
     .onErrorResume(NotFound::class.java) { Mono.empty() }

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/dto/nomis/OffenderBookingOld.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/dto/nomis/OffenderBookingOld.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.dto.nomis
 
 import java.time.LocalDate
 
-data class OffenderBooking(
+data class OffenderBookingOld(
   val offenderNo: String,
   val firstName: String,
   val lastName: String,
@@ -33,8 +33,8 @@ data class OffenderBooking(
   val birthCountryCode: String? = null,
   val identifiers: List<OffenderIdentifier>? = null,
   val sentenceDetail: SentenceDetail? = null,
-  val mostSeriousOffence: String? = null,
-  val indeterminateSentence: Boolean? = null,
+  val offenceHistory: List<OffenceHistoryDetail>? = null,
+  val sentenceTerms: List<SentenceTerm>? = null,
   val status: String? = null,
   val legalStatus: String? = null,
   val recall: Boolean? = null,
@@ -44,4 +44,50 @@ data class OffenderBooking(
   val receptionDate: LocalDate? = null,
   val locationDescription: String? = null,
   val latestLocationId: String? = null,
-)
+) {
+  fun toOffenderBooking(): OffenderBooking {
+    return OffenderBooking(
+      offenderNo,
+      firstName,
+      lastName,
+      dateOfBirth,
+      activeFlag,
+      bookingId,
+      bookingNo,
+      middleName,
+      aliases,
+      agencyId,
+      inOutStatus,
+      lastMovementTypeCode,
+      lastMovementReasonCode,
+      religion,
+      language,
+      alerts,
+      assignedLivingUnit,
+      facialImageId,
+      age,
+      physicalAttributes,
+      physicalCharacteristics,
+      profileInformation,
+      physicalMarks,
+      assessments,
+      csra,
+      categoryCode,
+      birthPlace,
+      birthCountryCode,
+      identifiers,
+      sentenceDetail,
+      offenceHistory?.firstOrNull { off -> off.mostSerious && off.bookingId == bookingId }?.offenceDescription,
+      sentenceTerms?.any { st -> st.lifeSentence && st.bookingId == bookingId },
+      status,
+      legalStatus,
+      recall,
+      imprisonmentStatus,
+      imprisonmentStatusDescription,
+      personalCareNeeds,
+      receptionDate,
+      locationDescription,
+      latestLocationId,
+    )
+  }
+}


### PR DESCRIPTION
The new prison-api endpoint we will be calling to populate the Prisoner record has a slightly different model (mainly because it was returning the current booking offence history just to calculate most serious offence - but we're going to be adding the entire offence history for all bookings soon so I wanted to remove that).

As an intermediary step we're moving over to the new model early. This will make it easier to test the old and new prison-api endpoints.