### PR TITLE
SDIT-1583 Test new prison-api endpoint in dev

### DIFF
--- a/hmpps-prisoner-search-indexer/helm_deploy/values-dev.yaml
+++ b/hmpps-prisoner-search-indexer/helm_deploy/values-dev.yaml
@@ -14,6 +14,7 @@ generic-service:
     INDEX_BUILD_COMPLETE_THRESHOLD: 500000
     DIFF_HOST: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     DIFF_PREFIX: ""
+    DIFF_TEST_NEW_OFFENDER_ENDPOINT: true
 
   scheduledDowntime:
     enabled: true

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NewOffenderEndpointTestService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NewOffenderEndpointTestService.kt
@@ -1,0 +1,58 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.indexer.services
+
+import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.prisonersearch.common.config.trackEvent
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.dto.nomis.OffenderBooking
+
+/**
+ * This service tests the new offender endpoint in prison-api by launching a coroutine to call the new endpoint and
+ * compare the results to the offender booking retrieved by the old endpoint, publishing the results to App Insights.
+ */
+@ConditionalOnProperty(value = ["diff.testNewOffenderEndpoint"], havingValue = "true")
+@Component
+class NewOffenderEndpointTestService(
+  private val telemetryClient: TelemetryClient,
+  private val nomisService: NomisService,
+) {
+  fun launchOffenderEndpointDiffTest(oldEndpointBooking: OffenderBooking) {
+    CoroutineScope(SupervisorJob()).launch {
+      trackDifferences(oldEndpointBooking)
+    }
+  }
+
+  fun trackDifferences(oldEndpointBooking: OffenderBooking) {
+    try {
+      nomisService.getOffenderNewEndpoint(oldEndpointBooking.offenderNo)
+        ?.also { newEndpointBooking ->
+          val diff = oldEndpointBooking.diff(newEndpointBooking)
+          if (diff.diffs.isNotEmpty()) {
+            telemetryClient.trackEvent(
+              "OffenderBookingDifference",
+              mapOf(
+                "offenderNo" to oldEndpointBooking.offenderNo,
+                "diff" to diff.diffs.joinToString(", ") { it.fieldName },
+              ),
+            )
+          }
+        }
+        ?: also {
+          telemetryClient.trackEvent(
+            "OffenderBookingDifference",
+            mapOf("offenderNo" to oldEndpointBooking.offenderNo, "diff" to "new_booking_null"),
+          )
+        }
+    } catch (e: Exception) {
+      telemetryClient.trackEvent(
+        "OffenderBookingDifference",
+        mapOf("offenderNo" to oldEndpointBooking.offenderNo, "diff" to "exception", "exception" to e.message.toString()),
+      )
+      // rethrow as well as publishing telemetry so we don't lose any information about the exception (it should appear in App Insights - I think)
+      throw e
+    }
+  }
+}

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
@@ -18,6 +18,7 @@ class PrisonerSynchroniserService(
   private val restrictedPatientService: RestrictedPatientService,
   private val incentivesService: IncentivesService,
   private val prisonerDifferenceService: PrisonerDifferenceService,
+  private val newOffenderEndpointTestService: NewOffenderEndpointTestService?,
 ) {
 
   // called when prisoner updated or manual prisoner index required
@@ -36,6 +37,8 @@ class PrisonerSynchroniserService(
     // only save to open search if we encounter any differences
     if (prisonerDifferenceService.prisonerHasChanged(existingPrisoner, prisoner)) {
       indices.map { index -> prisonerRepository.save(prisoner, index) }
+        // TODO Remove this once testing of the new prison-api offender endpoint is complete
+        .also { newOffenderEndpointTestService?.launchOffenderEndpointDiffTest(ob) }
       prisonerDifferenceService.handleDifferences(existingPrisoner, ob, prisoner, eventType)
     } else {
       telemetryClient.trackPrisonerEvent(
@@ -56,6 +59,8 @@ class PrisonerSynchroniserService(
   internal fun index(ob: OffenderBooking, vararg indexes: SyncIndex): Prisoner =
     translate(ob).also {
       indexes.map { index -> prisonerRepository.save(it, index) }
+        // TODO Remove this once testing of the new prison-api offender endpoint is complete
+        .also { newOffenderEndpointTestService?.launchOffenderEndpointDiffTest(ob) }
     }
 
   internal fun compareAndMaybeIndex(ob: OffenderBooking, indices: List<SyncIndex>) {
@@ -74,6 +79,8 @@ class PrisonerSynchroniserService(
       prisonerDifferenceService.reportDiffTelemetry(existingPrisoner, prisoner)
 
       indices.map { prisonerRepository.save(prisoner, it) }
+        // TODO Remove this once testing of the new prison-api offender endpoint is complete
+        .also { newOffenderEndpointTestService?.launchOffenderEndpointDiffTest(ob) }
       prisonerDifferenceService.handleDifferences(existingPrisoner, ob, prisoner, "REFRESH")
     }
   }

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/dto/nomis/OffenderBooking.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/dto/nomis/OffenderBooking.kt
@@ -49,6 +49,7 @@ data class OffenderBooking(
 private fun getDiffResult(booking: OffenderBooking, other: OffenderBooking): DiffResult<OffenderBooking> =
   DiffBuilder(booking, other, ToStringStyle.JSON_STYLE).apply {
     OffenderBooking::class.members
-      .filterNot { listOf("diff", "equals", "toString", "hashCode").contains(it.name) }
+      .filterNot { listOf("copy", "diff", "equals", "toString", "hashCode").contains(it.name) }
+      .filterNot { it.name.startsWith("component") }
       .forEach { property -> append(property.name, property.call(booking), property.call(other)) }
   }.build()

--- a/hmpps-prisoner-search-indexer/src/main/resources/application.yml
+++ b/hmpps-prisoner-search-indexer/src/main/resources/application.yml
@@ -106,6 +106,7 @@ diff:
   events: true
   host: http://localhost:8080
   prefix: dummy.
+  testNewOffenderEndpoint: false
 
 republish:
   delayInSeconds: 5

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/CompareIndexResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/CompareIndexResourceIntTest.kt
@@ -2,7 +2,6 @@
 
 package uk.gov.justice.digital.hmpps.prisonersearch.indexer.resource
 
-import com.microsoft.applicationinsights.TelemetryClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -14,7 +13,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.timeout
 import org.mockito.kotlin.verify
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.SyncIndex
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.AliasBuilder
@@ -23,8 +21,6 @@ import uk.gov.justice.digital.hmpps.prisonersearch.indexer.PrisonerBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.PrisonApiExtension.Companion.prisonApi
 
 class CompareIndexResourceIntTest : IntegrationTestBase() {
-  @SpyBean
-  lateinit var telemetryClient: TelemetryClient
 
   @Nested
   inner class compareTestsNoData {

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/MaintainIndexResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/MaintainIndexResourceIntTest.kt
@@ -21,7 +21,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.MediaType
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
@@ -34,25 +33,18 @@ import uk.gov.justice.digital.hmpps.prisonersearch.common.model.SyncIndex.GREEN
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.PrisonerBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.readResourceAsText
-import uk.gov.justice.digital.hmpps.prisonersearch.indexer.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.BuildAlreadyInProgressException
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.BuildNotInProgressException
-import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.MaintainIndexService
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.NoActiveIndexesException
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.PrisonerNotFoundException
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.IncentivesApiExtension.Companion.incentivesApi
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.PrisonApiExtension.Companion.prisonApi
 
 class MaintainIndexResourceIntTest : IntegrationTestBase() {
-  @SpyBean
-  private lateinit var maintainIndexService: MaintainIndexService
 
   @Autowired
   @Qualifier("offenderqueue-sqs-client")
   private lateinit var offenderQueueSqsClient: SqsAsyncClient
-
-  @SpyBean
-  lateinit var prisonerSpyBeanRepository: PrisonerRepository
 
   @BeforeEach
   fun `reset mocks`() = reset(maintainIndexService)

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
@@ -2,7 +2,6 @@
 
 package uk.gov.justice.digital.hmpps.prisonersearch.indexer.resource
 
-import com.microsoft.applicationinsights.TelemetryClient
 import net.minidev.json.JSONArray
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -17,7 +16,6 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.IndexState
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.IndexStatus
@@ -31,8 +29,6 @@ import java.time.Instant
 import java.time.LocalDate
 
 class RefreshIndexResourceIntTest : IntegrationTestBase() {
-  @SpyBean
-  lateinit var telemetryClient: TelemetryClient
 
   @BeforeEach
   fun setUp() {

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NewOffenderEndpointTestServiceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/NewOffenderEndpointTestServiceIntTest.kt
@@ -1,0 +1,178 @@
+package uk.gov.justice.digital.hmpps.prisonersearch.indexer.services
+
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.prisonersearch.common.model.SyncIndex.GREEN
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.PhysicalCharacteristicBuilder
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.PrisonerBuilder
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.PrisonApiExtension.Companion.prisonApi
+
+class NewOffenderEndpointTestServiceIntTest : IntegrationTestBase() {
+
+  @Nested
+  inner class BuildIndex {
+    @Test
+    fun `should not publish diff telemetry`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", firstName = "LUCAS")
+      prisonApi.stubOffenders(prisonerBuilder)
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder)
+      buildAndSwitchIndex(GREEN, 1)
+
+      verify(telemetryClient, never()).trackEvent(
+        eq("OffenderBookingDifference"),
+        check {
+          assertThat(it).containsEntry("offenderNo", "A1234BC")
+          assertThat(it).containsEntry("diff", "firstName")
+        },
+        isNull(),
+      )
+    }
+
+    @Test
+    fun `should publish diff telemetry for a difference on the new endpoint`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", firstName = "LUCAS")
+      prisonApi.stubOffenders(prisonerBuilder)
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder.copy(firstName = "MICK"))
+      buildAndSwitchIndex(GREEN, 1)
+
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "firstName")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Test
+    fun `should publish diff telemetry for a difference to a list`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", alertCodes = listOf("X" to "XX"))
+      prisonApi.stubOffenders(prisonerBuilder)
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder.copy(alertCodes = listOf("Y" to "YY")))
+      buildAndSwitchIndex(GREEN, 1)
+
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "alerts")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Test
+    fun `should publish diff telemetry for a difference to a nested object`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", physicalCharacteristics = PhysicalCharacteristicBuilder(hairColour = "Brown"))
+      prisonApi.stubOffenders(prisonerBuilder)
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder.copy(physicalCharacteristics = PhysicalCharacteristicBuilder(hairColour = "Blonde")))
+      buildAndSwitchIndex(GREEN, 1)
+
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "physicalCharacteristics")
+          },
+          isNull(),
+        )
+      }
+    }
+
+    @Test
+    fun `should publish diff telemetry for prisoner not found on new endpoint`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", firstName = "LUCAS")
+      prisonApi.stubOffenders(prisonerBuilder)
+      prisonApi.stubGetOffenderNewEndpointNotFound("A1234BC")
+      buildAndSwitchIndex(GREEN, 1)
+
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "new_booking_null")
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class IndexPrisoner {
+    @Test
+    fun `should publish diff telemetry`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", firstName = "LUCAS")
+      prisonApi.stubOffenders(prisonerBuilder)
+      buildAndSwitchIndex(GREEN, 1)
+
+      prisonApi.stubOffenders(prisonerBuilder.copy(firstName = "MIKE"))
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder.copy(firstName = "MICK"))
+      webTestClient.put()
+        .uri("/maintain-index/index-prisoner/A1234BC")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_INDEX")))
+        .exchange()
+        .expectStatus().isOk
+
+      verify(maintainIndexService).indexPrisoner("A1234BC")
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "firstName")
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class RefreshIndex {
+    @Test
+    fun `should publish diff telemetry`() {
+      val prisonerBuilder = PrisonerBuilder("A1234BC", firstName = "LUCAS")
+      prisonApi.stubOffenders(prisonerBuilder)
+      buildAndSwitchIndex(GREEN, 1)
+
+      prisonApi.stubOffenders(prisonerBuilder.copy(firstName = "MIKE"))
+      prisonApi.stubGetOffenderNewEndpoint(prisonerBuilder.copy(firstName = "MICK"))
+      webTestClient.put()
+        .uri("/refresh-index")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_PRISONER_INDEX")))
+        .exchange()
+        .expectStatus().isAccepted
+
+      await untilAsserted {
+        verify(telemetryClient).trackEvent(
+          eq("OffenderBookingDifference"),
+          check {
+            assertThat(it).containsEntry("offenderNo", "A1234BC")
+            assertThat(it).containsEntry("diff", "firstName")
+          },
+          isNull(),
+        )
+      }
+    }
+  }
+}

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
@@ -34,12 +34,14 @@ internal class PrisonerSynchroniserServiceTest {
   private val prisonerRepository = mock<PrisonerRepository>()
   private val telemetryClient = mock<TelemetryClient>()
   private val prisonerDifferenceService = mock<PrisonerDifferenceService>()
+  private val newOffenderEndpointTestService = mock<NewOffenderEndpointTestService>()
   private val service = PrisonerSynchroniserService(
     prisonerRepository,
     telemetryClient,
     restrictedPatientService,
     incentivesService,
     prisonerDifferenceService,
+    newOffenderEndpointTestService,
   )
 
   @Nested

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/wiremock/PrisonApiMockServer.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/wiremock/PrisonApiMockServer.kt
@@ -59,6 +59,35 @@ class PrisonApiMockServer : WireMockServer(8093) {
     )
   }
 
+  fun stubGetOffenderNewEndpoint(prisonerBuilder: PrisonerBuilder) {
+    stubFor(
+      WireMock.get(urlEqualTo("/api/prisoner-search/offenders/${prisonerBuilder.prisonerNumber}"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(prisonerBuilder.toOffenderBookingNewEndpoint()),
+        ),
+    )
+  }
+
+  fun stubGetOffenderNewEndpointNotFound(prisonerNumber: String) {
+    stubFor(
+      WireMock.get(urlEqualTo("/api/prisoner-search/offenders/$prisonerNumber"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+              """
+                {
+                  "error": "not found"
+                }
+              """.trimIndent(),
+            )
+            .withStatus(404),
+        ),
+    )
+  }
+
   fun stubGetNomsNumberForBooking(bookingId: Long, prisonerNumber: String) {
     stubFor(
       WireMock.get(urlEqualTo("/api/bookings/$bookingId?basicInfo=true"))

--- a/hmpps-prisoner-search-indexer/src/test/resources/application-test.yml
+++ b/hmpps-prisoner-search-indexer/src/test/resources/application-test.yml
@@ -74,6 +74,7 @@ index-build:
 diff:
   events: true
   prefix: test.
+  testNewOffenderEndpoint: true
 
 republish:
   delayInSeconds: 0


### PR DESCRIPTION
Every time we write a Prisoner record to Opensearch, we will call the new prison-api endpoint to make sure it returns the same details as the old one and publish telemetry if not. This is to gain confidence that the new endpoint works the same as the old one before switching to the new endpoint.