### PR TITLE
SDIT-1663 Differentiate between contains and wildcard searches, and document with examples

### DIFF
--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/AttributeSearchResource.kt
@@ -64,8 +64,14 @@ class AttributeSearchResource(private val attributeSearchService: AttributeSearc
       searched for with dot notation, e.g. <strong>"attribute=aliases.firstName"</strong> or <strong>"attribute=tattoos.bodyPart"</strong>. 
       Attributes from complex objects can also be searched for with dot notation, e.g. <strong>"attribute=currentIncentive.level.code"</strong>.
       </p>
-      <p>String attributes that contain free text will perform a <a href="https://opensearch.org/docs/latest/query-dsl/term/fuzzy/">fuzzy search</a> with conditions IS and CONTAINS.
-      This means that the query also matches on near misses, e.g. spelling mistakes. To find which attributes perform a fuzzy search call endpoint <strong>GET /attribute-search/attributes</strong>.
+      <p>String attributes support advanced search techniques such as <a href="https://opensearch.org/docs/latest/query-dsl/term/fuzzy/">fuzzy search</a> matching and <a href="https://opensearch.org/docs/latest/query-dsl/term/wildcard/">wildcard search</a>. All String searches are case-insensitive.
+      <ul>
+        <li>IS and IS_NOT require an exact match (wildcards ? and * will not work). E.g. If religion is "Christian" then <strong>"religion IS Christian"</strong> will match but <strong>"religion IS Christ*"</strong> will not.</li>
+        <li>For IS and CONTAINS some attributes support fuzzy matching e.g. they allow spelling mistakes. Call endpoint <strong>GET /attribute-search/attributes</strong> to see which attributes support fuzzy matching. E.g. If firstName is "Jonathan" then <strong>"firstName IS Johnathon"</strong> or <strong>"firstName CONTAINS Johnathon"</strong> will match.</li>
+        <li>CONTAINS without wildcards (? and *) for a non-fuzzy attribute looks for the exact search term anywhere in the attribute value. E.g. If religion is "Christian" then <strong>"religion CONTAINS ist"</strong> will match.</li>
+        <li>CONTAINS with wildcards ? (single character) and/or * (zero to many characters) perform a wildcard search which must match the entire attribute value. E.g. If firstName is "Jonathan" then <strong>"firstName CONTAINS Jon*"</strong> will match but <strong>"firstName CONTAINS nath*"</strong> will not.</li>
+        <li>STARTSWITH checks only the prefix of the attribute value and does not support fuzzy matching or wildcards. E.g.If firstName is "Jonathan" then <strong>"firstName STARTSWITH Jon"</strong> will match but <strong>"firstName STARTSWITH Jon*"</strong> will not.</li> 
+      </ul>
       </p>
       <p>To assist with debugging queries we publish events in App Insights. To search in App Insights Log Analytics run query: 
       <pre>

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchIntegrationTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/attributesearch/AttributeSearchIntegrationTest.kt
@@ -267,7 +267,7 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS`() {
       val request = RequestDsl {
         query {
-          stringMatcher("firstName" CONTAINS "John")
+          stringMatcher("firstName" CONTAINS "ohn")
         }
       }
 
@@ -278,7 +278,7 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS uppercase`() {
       val request = RequestDsl {
         query {
-          stringMatcher("firstName" CONTAINS "JOHN")
+          stringMatcher("firstName" CONTAINS "OHN")
         }
       }
 
@@ -289,7 +289,7 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS lowercase`() {
       val request = RequestDsl {
         query {
-          stringMatcher("firstName" CONTAINS "john")
+          stringMatcher("firstName" CONTAINS "ohn")
         }
       }
 
@@ -300,11 +300,11 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS with single character wildcard`() {
       val request = RequestDsl {
         query {
-          stringMatcher("currentIncentive.level.description" CONTAINS "ince?tive level")
+          stringMatcher("currentIncentive.level.description" CONTAINS "ince?tive level 1")
         }
       }
 
-      webTestClient.attributeSearch(request).expectPrisoners("P1", "P2", "P3")
+      webTestClient.attributeSearch(request).expectPrisoners("P1")
     }
 
     @Test
@@ -322,11 +322,11 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS with more than one single character wildcard`() {
       val request = RequestDsl {
         query {
-          stringMatcher("currentIncentive.level.description" CONTAINS "ince?tive le?el")
+          stringMatcher("currentIncentive.level.description" CONTAINS "ince?tive le?el 1")
         }
       }
 
-      webTestClient.attributeSearch(request).expectPrisoners("P1", "P2", "P3")
+      webTestClient.attributeSearch(request).expectPrisoners("P1")
     }
 
     @Test
@@ -344,11 +344,11 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS with a multiple character wildcard`() {
       val request = RequestDsl {
         query {
-          stringMatcher("currentIncentive.level.description" CONTAINS "ince*ve level")
+          stringMatcher("currentIncentive.level.description" CONTAINS "ince*ve level 1")
         }
       }
 
-      webTestClient.attributeSearch(request).expectPrisoners("P1", "P2", "P3")
+      webTestClient.attributeSearch(request).expectPrisoners("P1")
     }
 
     @Test
@@ -366,11 +366,11 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     fun `single CONTAINS with more than one multiple character wildcards`() {
       val request = RequestDsl {
         query {
-          stringMatcher("currentIncentive.level.description" CONTAINS "ince*ve l*l")
+          stringMatcher("currentIncentive.level.description" CONTAINS "ince*ve l*l 1")
         }
       }
 
-      webTestClient.attributeSearch(request).expectPrisoners("P1", "P2", "P3")
+      webTestClient.attributeSearch(request).expectPrisoners("P1")
     }
 
     @Test
@@ -385,15 +385,14 @@ class AttributeSearchIntegrationTest : AbstractSearchIntegrationTest() {
     }
 
     @Test
-    fun `single CONTAINS with partial matches in search term`() {
-      // The "John" matches all prisoners, so we're testing that the results must contain the whole search term
+    fun `single CONTAINS with wildcard not a full match`() {
       val request = RequestDsl {
         query {
-          stringMatcher("firstName" CONTAINS "John1")
+          stringMatcher("currentIncentive.level.description" CONTAINS "e*ve l*l")
         }
       }
 
-      webTestClient.attributeSearch(request).expectPrisoners("P1")
+      webTestClient.attributeSearch(request).expectPrisoners()
     }
 
     @Test


### PR DESCRIPTION
Testing highlighted an issue where searching for "firstName CONTAINS s*" finds any names containing an "s", but the intention was for any names starting with "s".