### PR TITLE
SDIT-1861 READMISSION_SWITCH_BOOKING for correcting new booking mistakes

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/HmppsDomainEventEmitter.kt
@@ -115,6 +115,7 @@ class HmppsDomainEventEmitter(
   enum class PrisonerReceiveReason(val description: String) {
     NEW_ADMISSION("admission on new charges"),
     READMISSION("re-admission on an existing booking"),
+    READMISSION_SWITCH_BOOKING("re-admission but switched to old booking"),
     TRANSFERRED("transfer from another prison"),
     RETURN_FROM_COURT("returned back to prison from court"),
     TEMPORARY_ABSENCE_RETURN("returned after a temporary absence"),

--- a/hmpps-prisoner-search-indexer/src/main/resources/swagger-description.html
+++ b/hmpps-prisoner-search-indexer/src/main/resources/swagger-description.html
@@ -62,6 +62,7 @@
           <ul>
             <li><b>NEW_ADMISSION</b> - admission on new charges</li>
             <li><b>READMISSION</b> - re-admission on an existing booking</li>
+            <li><b>READMISSION_SWITCH_BOOKING</b> - re-admission on an existing previous booking - typically after a new booking is created by mistake</li>
             <li><b>TRANSFERRED</b> - transfer from another prison</li>
             <li><b>RETURN_FROM_COURT</b> - returned back to prison from court</li>
             <li><b>TEMPORARY_ABSENCE_RETURN</b> - returned after a temporary absence</li>

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.Hmpps
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.NEW_ADMISSION
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.POST_MERGE_ADMISSION
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.READMISSION
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.READMISSION_SWITCH_BOOKING
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.RETURN_FROM_COURT
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReceiveReason.TEMPORARY_ABSENCE_RETURN
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.services.events.HmppsDomainEventEmitter.PrisonerReleaseReason.RELEASED
@@ -206,6 +207,19 @@ internal class PrisonerMovementsEventServiceTest(@Autowired private val objectMa
       verify(domainEventsEmitter).emitPrisonerReceiveEvent(
         offenderNo = OFFENDER_NO,
         reason = READMISSION,
+        prisonId = "BXI",
+      )
+    }
+
+    @Test
+    internal fun `will emit receive event with reason of readmission with switch booking to existing old booking`() {
+      val prisoner = recalledPrisoner("BXI", bookingId = "99")
+
+      prisonerMovementsEventService.generateAnyEvents(previousPrisonerSnapshot, prisoner, offenderBooking())
+
+      verify(domainEventsEmitter).emitPrisonerReceiveEvent(
+        offenderNo = OFFENDER_NO,
+        reason = READMISSION_SWITCH_BOOKING,
         prisonId = "BXI",
       )
     }
@@ -404,8 +418,9 @@ internal class PrisonerMovementsEventServiceTest(@Autowired private val objectMa
     }
 
   private fun releasedPrisoner() = prisoner("/receive-state-changes/released.json")
-  private fun recalledPrisoner(prisonId: String = "NMI") = prisoner("/receive-state-changes/recalled.json").apply {
+  private fun recalledPrisoner(prisonId: String = "NMI", bookingId: String = "1203208") = prisoner("/receive-state-changes/recalled.json").apply {
     this.prisonId = prisonId
+    this.bookingId = bookingId
   }
   private fun releasedPrisonerToHospital() = prisoner("/receive-state-changes/released-to-hospital.json")
 


### PR DESCRIPTION
When a new booking is created by mistake the NOMIS user will release and bring the person back on an older booking. This was previously emitting a receive event with a reason off NEW_ADMISSION, this now sets the reason to a new value of READMISSION_SWITCH_BOOKING so clients can distinguish between this scenario and a normal READMISSION