### PR TITLE
SDIT-1957-Update-the-new-index-using-partial-updates-instead-of-an-overall-save

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
@@ -27,7 +27,7 @@ class IndexListenerService(
       message.additionalInformation.nomsNumber,
       message.additionalInformation.id,
     )
-    syncOld(message.additionalInformation.nomsNumber, eventType)
+    syncGreenBlue(message.additionalInformation.nomsNumber, eventType)
     reindexIncentive(message.additionalInformation.nomsNumber, eventType)
   }
 
@@ -114,7 +114,7 @@ class IndexListenerService(
         }
       }
 
-  private fun reindexPrisonerOld(ob: OffenderBooking, eventType: String): Prisoner? =
+  private fun reindexPrisonerGreenBlue(ob: OffenderBooking, eventType: String): Prisoner? =
     indexStatusService.getIndexStatus()
       .run {
         if (activeIndexesEmpty()) {
@@ -126,7 +126,7 @@ class IndexListenerService(
         }
       }
 
-  private fun reindexPrisonerNew(ob: OffenderBooking, eventType: String) =
+  private fun reindexPrisonerRed(ob: OffenderBooking, eventType: String) =
     indexStatusService.getIndexStatus()
       .run {
         if (activeIndexesEmpty()) {
@@ -153,13 +153,13 @@ class IndexListenerService(
    */
   private fun syncBoth(prisonerNumber: String, eventType: String): Prisoner? =
     nomisService.getOffender(prisonerNumber)?.run {
-      reindexPrisonerNew(ob = this, eventType)
-      reindexPrisonerOld(ob = this, eventType)
+      reindexPrisonerRed(ob = this, eventType)
+      reindexPrisonerGreenBlue(ob = this, eventType)
     } ?: null.also { log.warn("Sync requested for prisoner {} not found", prisonerNumber) }
 
-  private fun syncOld(prisonerNumber: String, eventType: String): Prisoner? =
+  private fun syncGreenBlue(prisonerNumber: String, eventType: String): Prisoner? =
     nomisService.getOffender(prisonerNumber)?.run {
-      reindexPrisonerOld(ob = this, eventType)
+      reindexPrisonerGreenBlue(ob = this, eventType)
     } ?: null.also { log.warn("Sync (old) requested for prisoner {} not found", prisonerNumber) }
 
   private fun syncBoth(bookingId: Long, eventType: String): Prisoner? =

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
@@ -108,9 +108,8 @@ class IndexListenerService(
           log.info("Ignoring update of prisoner {} as no indexes were active", ob.offenderNo)
           null
         } else {
-          val prisoner = prisonerSynchroniserService.reindex(ob, activeIndexes(), eventType)
           prisonerSynchroniserService.reindexUpdate(ob, eventType)
-          prisoner
+          prisonerSynchroniserService.reindex(ob, activeIndexes(), eventType)
         }
       }
 
@@ -121,8 +120,7 @@ class IndexListenerService(
           log.info("Ignoring update (old) of prisoner {} as no indexes were active", ob.offenderNo)
           null
         } else {
-          val prisoner = prisonerSynchroniserService.reindex(ob, activeIndexes(), eventType)
-          prisoner
+          prisonerSynchroniserService.reindex(ob, activeIndexes(), eventType)
         }
       }
 

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventListenerIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventListenerIntTest.kt
@@ -4,6 +4,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.IndexState.BUILDING
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.IndexState.COMPLETED
@@ -64,22 +70,16 @@ class DomainEventListenerIntTest : IntegrationTestBase() {
   fun `will index incentive when iep message received`() {
     indexStatusRepository.save(IndexStatus(currentIndex = SyncIndex.GREEN, currentIndexState = COMPLETED))
     val prisonerNumber = "A7089FF"
-    prisonerRepository.save(
-      Prisoner().apply {
-        this.prisonerNumber = prisonerNumber
-        bookingId = "1234"
-      },
-      SyncIndex.GREEN,
-    )
-    prisonerRepository.save(
-      Prisoner().apply {
-        this.prisonerNumber = prisonerNumber
-        bookingId = "1234"
-      },
-      SyncIndex.RED,
-    )
+    val prisoner = Prisoner().apply {
+      this.prisonerNumber = prisonerNumber
+      bookingId = "1234"
+    }
+    prisonerRepository.save(prisoner, SyncIndex.GREEN)
+    prisonerRepository.save(prisoner, SyncIndex.RED)
     prisonApi.stubOffenders(PrisonerBuilder(prisonerNumber))
     incentivesApi.stubCurrentIncentive()
+
+    reset(prisonerSpyBeanRepository) // zero the call count
 
     hmppsDomainSqsClient.sendMessage(
       SendMessageRequest.builder().queueUrl(hmppsDomainQueueUrl)
@@ -96,6 +96,12 @@ class DomainEventListenerIntTest : IntegrationTestBase() {
         assertThat(currentIncentive?.level?.code).isEqualTo("STD")
       }
     }
+    verify(prisonerSpyBeanRepository, times(1)).save(any(), eq(SyncIndex.GREEN))
+    verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.BLUE))
+    verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.RED))
+    verify(prisonerSpyBeanRepository, times(1)).updateIncentive(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
+    verify(prisonerSpyBeanRepository, never()).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.GREEN), any())
+    verify(prisonerSpyBeanRepository, never()).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
   }
 }
 

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventListenerIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/DomainEventListenerIntTest.kt
@@ -40,7 +40,7 @@ class DomainEventListenerIntTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `will update both indexes when rebuilding index`() {
+  fun `will update all indexes when rebuilding index`() {
     indexStatusRepository.save(
       IndexStatus(
         currentIndex = SyncIndex.GREEN,
@@ -61,6 +61,9 @@ class DomainEventListenerIntTest : IntegrationTestBase() {
         prisonerNumber,
       )
       assertThat(prisonerRepository.get(prisonerNumber, listOf(SyncIndex.BLUE))?.prisonerNumber).isEqualTo(
+        prisonerNumber,
+      )
+      assertThat(prisonerRepository.get(prisonerNumber, listOf(SyncIndex.RED))?.prisonerNumber).isEqualTo(
         prisonerNumber,
       )
     }

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/OffenderEventListenerIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/OffenderEventListenerIntTest.kt
@@ -72,16 +72,13 @@ class OffenderEventListenerIntTest : IntegrationTestBase() {
     )
 
     await untilAsserted {
-      val prisoner = prisonerRepository.get(prisonerNumber, listOf(SyncIndex.GREEN))
-      assertThat(prisoner?.prisonerNumber).isEqualTo(prisonerNumber)
+      verify(prisonerSpyBeanRepository, times(1)).save(any(), eq(SyncIndex.GREEN))
+      verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.BLUE))
+      verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.RED))
+      verify(prisonerSpyBeanRepository, never()).updateIncentive(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
+      verify(prisonerSpyBeanRepository, never()).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.GREEN), any())
+      verify(prisonerSpyBeanRepository, times(1)).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
     }
-
-    verify(prisonerSpyBeanRepository, times(1)).save(any(), eq(SyncIndex.GREEN))
-    verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.BLUE))
-    verify(prisonerSpyBeanRepository, never()).save(any(), eq(SyncIndex.RED))
-    verify(prisonerSpyBeanRepository, never()).updateIncentive(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
-    verify(prisonerSpyBeanRepository, never()).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.GREEN), any())
-    verify(prisonerSpyBeanRepository, times(1)).updatePrisoner(eq(prisonerNumber), any(), eq(SyncIndex.RED), any())
   }
 
   @Test


### PR DESCRIPTION
Remove a duplicate RED update on receipt of a domain event