### PR TITLE
SDIT-2041 Retry get incentive level a few times if it fails

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/config/WebClientConfiguration.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/config/WebClientConfiguration.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonersearch.indexer.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
@@ -12,6 +13,7 @@ import java.time.Duration
 
 @Configuration
 @EnableAsync
+@EnableRetry
 class WebClientConfiguration(
   @Value("\${api.base.url.prison-api}") val prisonApiBaseUri: String,
   @Value("\${api.base.url.incentives}") val incentivesBaseUri: String,

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IncentivesService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IncentivesService.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.indexer.services
 
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -10,6 +12,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.common.dps.IncentiveLevel
 class IncentivesService(
   private val incentivesWebClient: WebClient,
 ) {
+  @Retryable(maxAttempts = 3, backoff = Backoff(delay = 100))
   fun getCurrentIncentive(bookingId: Long): IncentiveLevel? =
     incentivesWebClient.get().uri("/incentive-reviews/booking/{bookingId}?with-details=false", bookingId)
       .retrieve()


### PR DESCRIPTION
When a failure happens, particularly after a new booking, multiple receive domain events can be raised since we fall back to using previous incentive level - but that value will typically be incorrect for a new booking so "differences" are incorrectly found.

This mitigates by trying a few times before failing.