### PR TITLE
SDIT-2140 Update domains when booking id changes

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
@@ -78,6 +78,10 @@ class PrisonerSynchroniserService(
           bookingId = ob.bookingId,
           eventType = eventType,
         )
+        // If the current booking id changed, some domain data needs updating too, retrieving using the new booking id
+        if (summary.prisoner?.bookingId?.toLong() != ob.bookingId) {
+          reindexIncentive(ob.offenderNo, SyncIndex.RED, eventType)
+        }
       } else {
         telemetryClient.trackPrisonerEvent(
           TelemetryEvents.RED_PRISONER_OPENSEARCH_NO_CHANGE,

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/OffenderEventListenerIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/listeners/OffenderEventListenerIntTest.kt
@@ -63,7 +63,7 @@ class OffenderEventListenerIntTest : IntegrationTestBase() {
     prisonerRepository.save(prisoner, SyncIndex.RED)
 
     prisonApi.stubGetNomsNumberForBooking(bookingId, prisonerNumber)
-    prisonApi.stubOffenders(PrisonerBuilder(prisonerNumber = prisonerNumber))
+    prisonApi.stubOffenders(PrisonerBuilder(prisonerNumber = prisonerNumber, bookingId = bookingId))
 
     reset(prisonerSpyBeanRepository) // zero the call count
 


### PR DESCRIPTION
Reindex RED domain data (e.g. incentives) when the current booking has changed, e.g. when a prisoner is received on an older booking id