### PR TITLE
HMAI-66 Add Date of birth to prisoner details

### DIFF
--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PrisonerDetailService.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PrisonerDetailService.kt
@@ -151,15 +151,8 @@ class PrisonerDetailService(
         )
       }
 
-//      detailQuery.mustWhenPresent("dateOfBirth", dateOfBirth)
-
-      dateOfBirth.takeIf { it != null }?.let {
-        detailQuery.must(
-          QueryBuilders.boolQuery().must(
-            QueryBuilders.matchQuery("dateOfBirth", it)
-          )
-        )
-      }
+      // Filter by date of birth.
+      detailQuery.mustWhenPresent("dateOfBirth", dateOfBirth)
 
       // Filter by prison establishments provided
       prisonIds.takeIf { it != null && it.isNotEmpty() && it[0].isNotBlank() }?.let {

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PrisonerDetailService.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/PrisonerDetailService.kt
@@ -151,6 +151,16 @@ class PrisonerDetailService(
         )
       }
 
+//      detailQuery.mustWhenPresent("dateOfBirth", dateOfBirth)
+
+      dateOfBirth.takeIf { it != null }?.let {
+        detailQuery.must(
+          QueryBuilders.boolQuery().must(
+            QueryBuilders.matchQuery("dateOfBirth", it)
+          )
+        )
+      }
+
       // Filter by prison establishments provided
       prisonIds.takeIf { it != null && it.isNotEmpty() && it[0].isNotBlank() }?.let {
         detailQuery.filterWhenPresent("prisonId", it)

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PrisonerDetailRequest.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PrisonerDetailRequest.kt
@@ -52,7 +52,7 @@ data class PrisonerDetailRequest(
   )
   val prisonIds: List<String>? = emptyList(),
 
-  @Schema(description = "Date of birth", example = "1970-02-28", required = false)
+  @Schema(description = "Date of birth to filter results by", example = "1970-02-28", required = false)
   val dateOfBirth: LocalDate? = null,
 
   @Schema(description = "Include aliases in search", example = "true", required = false, defaultValue = "true")

--- a/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PrisonerDetailRequest.kt
+++ b/hmpps-prisoner-search/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/services/dto/PrisonerDetailRequest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonersearch.search.services.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 data class PrisonerDetailRequest(
   @Schema(
@@ -50,6 +51,9 @@ data class PrisonerDetailRequest(
     required = true,
   )
   val prisonIds: List<String>? = emptyList(),
+
+  @Schema(description = "Date of birth", example = "1970-02-28", required = false)
+  val dateOfBirth: LocalDate? = null,
 
   @Schema(description = "Include aliases in search", example = "true", required = false, defaultValue = "true")
   val includeAliases: Boolean = true,

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResourceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResourceTest.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.prisonersearch.search.AbstractSearchDataInte
 import uk.gov.justice.digital.hmpps.prisonersearch.search.model.RestResponsePage
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.dto.KeywordRequest
 import uk.gov.justice.digital.hmpps.prisonersearch.search.services.dto.PrisonerDetailRequest
+import java.time.LocalDate
 
 class PrisonerDetailResourceTest : AbstractSearchDataIntegrationTest() {
   @Test
@@ -304,6 +305,14 @@ class PrisonerDetailResourceTest : AbstractSearchDataIntegrationTest() {
     detailSearch(
       detailRequest = PrisonerDetailRequest(prisonIds = listOf("MDI")),
       expectedPrisoners = listOf("A1090AA", "A7089EY", "A7089FA", "A7089FB", "A7090AA", "A7090AB", "A7090BB"),
+    )
+  }
+
+  @Test
+  fun `find by date of birth`() {
+    detailSearch(
+      detailRequest = PrisonerDetailRequest(prisonIds = listOf("MDI"), dateOfBirth = LocalDate.of(1980,2, 28)),
+      expectedPrisoners = listOf("A1090AA", "A7090AA", "A7090AB"),
     )
   }
 

--- a/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResourceTest.kt
+++ b/hmpps-prisoner-search/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/search/resource/PrisonerDetailResourceTest.kt
@@ -311,7 +311,7 @@ class PrisonerDetailResourceTest : AbstractSearchDataIntegrationTest() {
   @Test
   fun `find by date of birth`() {
     detailSearch(
-      detailRequest = PrisonerDetailRequest(prisonIds = listOf("MDI"), dateOfBirth = LocalDate.of(1980,2, 28)),
+      detailRequest = PrisonerDetailRequest(prisonIds = listOf("MDI"), dateOfBirth = LocalDate.of(1980, 2, 28)),
       expectedPrisoners = listOf("A1090AA", "A7090AA", "A7090AB"),
     )
   }


### PR DESCRIPTION
Add date of birth as a filter field into the `prisoner-details` endpoint. This will allow HMPPS Integration API to use a search that filters by Prison ID. As a bonus, this increases the parity with the `global-search` API.