### PR TITLE
SDIT-2182 Create duplicate logging from the red index updates - fix

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
@@ -69,6 +69,16 @@ class PrisonerRepository(
 
     prisonerMap.remove("currentIncentive")
 
+    prisonerMap.remove("restrictedPatient")
+    prisonerMap.remove("supportingPrisonId")
+    prisonerMap.remove("dischargedHospitalId")
+    prisonerMap.remove("dischargedHospitalDescription")
+    prisonerMap.remove("dischargeDate")
+    prisonerMap.remove("dischargeDetails")
+    if (summary.prisoner?.restrictedPatient == true) {
+      prisonerMap.remove("locationDescription")
+    }
+
     val response = openSearchRestTemplate.update(
       UpdateQuery.builder(prisonerNumber)
         .withDocument(Document.from(prisonerMap))

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
@@ -140,7 +140,7 @@ class PrisonerSynchroniserService(
       ?.run {
         val bookingId = this.prisoner?.bookingId?.toLong() ?: throw PrisonerNotFoundException(prisonerNo)
         val incentiveLevel = incentivesService.getCurrentIncentive(bookingId)
-        val newLevel: CurrentIncentive = incentiveLevel.toCurrentIncentive()!!
+        val newLevel: CurrentIncentive? = incentiveLevel.toCurrentIncentive()
 
         prisonerRepository.updateIncentive(prisonerNo, newLevel, index, this)
           .also { updated ->

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
@@ -301,6 +301,33 @@ internal class PrisonerRepositoryTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `will not update domain data`() {
+      prisonerRepository.save(
+        Prisoner().apply {
+          prisonerNumber = "X12345"
+          currentIncentive = CurrentIncentive(IncentiveLevel("code-original", "description1"), LocalDateTime.now())
+          supportingPrisonId = "OLD"
+        },
+        RED,
+      )
+
+      val isUpdated = prisonerRepository.updatePrisoner(
+        "X12345",
+        Prisoner().apply {
+          prisonerNumber = "X12345"
+          currentIncentive = CurrentIncentive(IncentiveLevel("code-new", "description1"), LocalDateTime.now())
+          supportingPrisonId = "NEW"
+        },
+        RED,
+        prisonerRepository.getSummary("X12345", RED)!!,
+      )
+      assertThat(isUpdated).isTrue()
+      val data = prisonerRepository.get("X12345", listOf(RED))!!
+      assertThat(data.currentIncentive?.level?.code).isEqualTo("code-original")
+      assertThat(data.supportingPrisonId).isEqualTo("OLD")
+    }
+
+    @Test
     fun `wrong sequence + 1 throws exception`() {
       prisonerRepository.save(
         Prisoner().apply { prisonerNumber = "X12345" },

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
@@ -442,6 +442,16 @@ internal class PrisonerSynchroniserServiceTest {
     }
 
     @Test
+    fun `Updates ok when no incentive data`() {
+      whenever(prisonerRepository.getSummary(any(), any())).thenReturn(prisonerDocumentSummary)
+      whenever(incentivesService.getCurrentIncentive(bookingId)).thenReturn(null)
+
+      service.reindexIncentive(prisonerNumber, GREEN, "event")
+
+      verify(prisonerRepository).updateIncentive(eq("A1234AA"), isNull(), eq(GREEN), eq(prisonerDocumentSummary))
+    }
+
+    @Test
     fun `will NOT call prisoner difference to handle differences`() {
       whenever(prisonerRepository.getSummary(any(), any())).thenReturn(prisonerDocumentSummary)
       whenever(incentivesService.getCurrentIncentive(bookingId)).thenReturn(newIncentive)


### PR DESCRIPTION
NPE and need to omit RP updates from ordinary prisoner events