### PR TITLE
SDIT-2182 Create duplicate logging from the red index updates - handle delete

### DIFF
--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/CurrentIncentive.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/CurrentIncentive.kt
@@ -26,7 +26,7 @@ data class CurrentIncentive(
 
 data class IncentiveLevel(
   @Schema(description = "code", example = "STD")
-  val code: String?,
+  val code: String,
 
   @Schema(description = "description", example = "Standard")
   val description: String,

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
@@ -73,6 +73,7 @@ class IndexListenerService(
         log.debug("Delete check: offender ID {} no longer exists, deleting", this)
         prisonerSynchroniserService.delete(prisonerNumber = this)
         hmppsDomainEventEmitter.emitPrisonerRemovedEvent(offenderNo = this, red = false)
+        hmppsDomainEventEmitter.emitPrisonerRemovedEvent(offenderNo = this, red = true)
       } else {
         log.debug("Delete check: offender ID {} still exists, so assuming an alias deletion", this)
         reindexPrisonerBoth(offender, eventType)

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
@@ -478,7 +478,7 @@ internal class PrisonerRepositoryTest : IntegrationTestBase() {
       prisonerRepository.updateIncentive(
         "X12345",
         CurrentIncentive(
-          IncentiveLevel(null, "description2"),
+          IncentiveLevel("code2", "description2"),
           LocalDateTime.parse("2024-08-14T15:16:17"),
           LocalDate.parse("2024-11-27"),
         ),
@@ -486,7 +486,7 @@ internal class PrisonerRepositoryTest : IntegrationTestBase() {
         prisonerRepository.getSummary("X12345", BLUE)!!,
       )
       val data = prisonerRepository.get("X12345", listOf(BLUE))?.currentIncentive!!
-      assertThat(data.level.code).isNull()
+      assertThat(data.level.code).isEqualTo("code2")
       assertThat(data.level.description).isEqualTo("description2")
       assertThat(data.dateTime).isEqualTo(LocalDateTime.parse("2024-08-14T15:16:17"))
       assertThat(data.nextReviewDate).isEqualTo(LocalDate.parse("2024-11-27"))

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerServiceTest.kt
@@ -426,7 +426,8 @@ internal class IndexListenerServiceTest {
       whenever(nomisService.getOffender(any())).thenReturn(null)
       indexListenerService.maybeDeleteOffender(anOffenderChanged("A123BC"), "OFFENDER-DELETED")
 
-      verify(hmppsDomainEventEmitter).emitPrisonerRemovedEvent("A123BC")
+      verify(hmppsDomainEventEmitter).emitPrisonerRemovedEvent("A123BC", false)
+      verify(hmppsDomainEventEmitter).emitPrisonerRemovedEvent("A123BC", true)
     }
 
     @Test


### PR DESCRIPTION
Creation of an event was not simulated for prisoner / alias deletion.
Also make the incentive code field non-null.