### PR TITLE
SDIT-2681-Add-emergency-fix-endpoints-for-domain-events

### DIFF
--- a/hmpps-prisoner-search-indexer/SendingMessages.md
+++ b/hmpps-prisoner-search-indexer/SendingMessages.md
@@ -1,3 +1,7 @@
+# Sending domain messages
+Occasionally it is necessary to manually send domain messages to the topic if this has failed and a EVENT_SEND_FAILURE event has been raised.
+Some endpoints have been provided to allow this to be done for the most important events, see https://prisoner-search-indexer-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/Domain%20events%20recovery
+
 # Sending messages to the index queue
 This application uses a service account called `hmpps-prisoner-search-indexer` with privileges to send messages.
 This means that access keys and secrets are not required to send messages as the service account is bound to the

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/DomainEventsResource.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/DomainEventsResource.kt
@@ -51,6 +51,46 @@ class DomainEventsResource(private val domainEventEmitter: HmppsDomainEventEmitt
       occurredAt = occurredAtTime,
     )
   }
+
+  @PutMapping("/events/prisoner/created/{prisonerNumber}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  @Operation(
+    summary = "Fires a domain event 'prisoner-offender-search.prisoner.created'. This is to be used in a catastrophic failure scenario when the original event was not raised",
+    description = "Requires EVENTS_ADMIN role",
+  )
+  @PreAuthorize("hasRole('ROLE_EVENTS_ADMIN')")
+  fun raisePrisonerCreatedEvent(
+    @Parameter(
+      required = true,
+      example = "A1234AA",
+    )
+    @NotNull
+    @Pattern(regexp = "[a-zA-Z][0-9]{4}[a-zA-Z]{2}")
+    @PathVariable("prisonerNumber")
+    prisonerNumber: String,
+  ) {
+    domainEventEmitter.emitPrisonerCreatedEvent(prisonerNumber)
+  }
+
+  @PutMapping("/events/prisoner/removed/{prisonerNumber}")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  @Operation(
+    summary = "Fires a domain event 'prisoner-offender-search.prisoner.removed'. This is to be used in a catastrophic failure scenario when the original event was not raised",
+    description = "Requires EVENTS_ADMIN role",
+  )
+  @PreAuthorize("hasRole('ROLE_EVENTS_ADMIN')")
+  fun raisePrisonerRemovedEvent(
+    @Parameter(
+      required = true,
+      example = "A1234AA",
+    )
+    @NotNull
+    @Pattern(regexp = "[a-zA-Z][0-9]{4}[a-zA-Z]{2}")
+    @PathVariable("prisonerNumber")
+    prisonerNumber: String,
+  ) {
+    domainEventEmitter.emitPrisonerRemovedEvent(prisonerNumber)
+  }
 }
 
 data class PrisonerReceivedEventDetails(

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexExceptions.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexExceptions.kt
@@ -6,10 +6,6 @@ abstract class IndexException(message: String) : RuntimeException(message)
 abstract class IndexConflictException(message: String) : IndexException(message)
 
 class BuildAlreadyInProgressException(indexStatus: IndexStatus) : IndexConflictException(startAlreadyMessage(indexStatus))
-class BuildInProgressException(indexStatus: IndexStatus) : IndexConflictException(startAlreadyMessage(indexStatus))
-
-class BuildCancelledException(indexStatus: IndexStatus) : IndexConflictException(startStateMessage(indexStatus))
-class BuildAbsentException(indexStatus: IndexStatus) : IndexConflictException(startStateMessage(indexStatus))
 
 class BuildNotInProgressException(indexStatus: IndexStatus) : IndexConflictException(endStateMessage(indexStatus))
 class WrongIndexRequestedException(indexStatus: IndexStatus) : IndexException(endStateMessage(indexStatus))
@@ -20,8 +16,5 @@ class PrisonerNotFoundException(prisonerNumber: String) : IndexException("The pr
 
 class ActiveMessagesExistException(indexQueueStatus: IndexQueueStatus, action: String) : IndexConflictException("The index has active messages $indexQueueStatus so we cannot process $action")
 
-class ThresholdNotReachedException(threshold: Long) : IndexConflictException("The index has not reached threshold $threshold so we cannot mark the index as complete")
-
 private fun startAlreadyMessage(indexStatus: IndexStatus) = "The build is already ${indexStatus.currentIndexState} (started at ${indexStatus.currentIndexStartBuildTime})"
 private fun endStateMessage(indexStatus: IndexStatus) = "The index is in state ${indexStatus.currentIndexState} (ended at ${indexStatus.currentIndexEndBuildTime})"
-private fun startStateMessage(indexStatus: IndexStatus) = "The build is in state ${indexStatus.currentIndexState} (started at ${indexStatus.currentIndexStartBuildTime})"

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/DomainEventsResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/DomainEventsResourceIntTest.kt
@@ -8,6 +8,7 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.BodyInserters
@@ -17,148 +18,240 @@ class DomainEventsResourceIntTest : IntegrationTestBase() {
   @BeforeEach
   fun purgeHmppsEventsQueue() = purgeDomainEventsQueue()
 
-  @Test
-  fun `access forbidden when no authority`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+  @Nested
+  inner class Received {
+
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "TRANSFERRED",
           "prisonId": "WWI",
           "occurredAt": "2020-07-19T12:30:12"
         }
       """,
-        ),
-      )
-      .exchange()
-      .expectStatus()
-      .isUnauthorized
-  }
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
 
-  @Test
-  fun `access forbidden when no role`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "TRANSFERRED",
           "prisonId": "WWI",
           "occurredAt": "2020-07-19T12:30:12"
         }
       """,
-        ),
-      )
-      .headers(setAuthorisation())
-      .exchange()
-      .expectStatus()
-      .isForbidden
-  }
+          ),
+        )
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
 
-  @Test
-  fun `reason code must be valid`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `reason code must be valid`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "BANANAS",
           "prisonId": "WWI",
           "occurredAt": "2020-07-19T12:30:12"
         }
       """,
-        ),
-      )
-      .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-  }
+          ),
+        )
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
 
-  @Test
-  fun `occurredAt must be present`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `occurredAt must be present`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "TRANSFERRED",
           "prisonId": "WWI"
         }
       """,
-        ),
-      )
-      .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-  }
+          ),
+        )
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
 
-  @Test
-  fun `prisonId must be present`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `prisonId must be present`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "TRANSFERRED",
           "occurredAt": "2020-07-19T12:30:12"
         }
       """,
-        ),
-      )
-      .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isBadRequest
-  }
+          ),
+        )
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isBadRequest
+    }
 
-  @Test
-  fun `sends prisoner receive event to the domain topic`() {
-    webTestClient
-      .put()
-      .uri("/events/prisoner/received/A2483AA")
-      .contentType(MediaType.APPLICATION_JSON)
-      .body(
-        BodyInserters.fromValue(
-          """
+    @Test
+    fun `sends prisoner receive event to the domain topic`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/received/A2483AA")
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            """
         {
           "reason": "TRANSFERRED",
           "prisonId": "WWI",
           "occurredAt": "2020-07-19T12:30:12"
         }
       """,
-        ),
-      )
-      .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
-      .exchange()
-      .expectStatus()
-      .isAccepted
+          ),
+        )
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isAccepted
 
-    await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
+      await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
 
-    val message = readNextDomainEventMessage()
+      val message = readNextDomainEventMessage()
 
-    assertThatJson(message).node("eventType").isEqualTo("test.prisoner-offender-search.prisoner.received")
-    assertThatJson(message).node("version").isEqualTo(1)
-    assertThatJson(message).node("occurredAt").isEqualTo("2020-07-19T12:30:12+01:00")
-    assertThatJson(message).node("additionalInformation.nomsNumber").isEqualTo("A2483AA")
-    assertThatJson(message).node("additionalInformation.reason").isEqualTo("TRANSFERRED")
+      assertThatJson(message).node("eventType").isEqualTo("test.prisoner-offender-search.prisoner.received")
+      assertThatJson(message).node("version").isEqualTo(1)
+      assertThatJson(message).node("occurredAt").isEqualTo("2020-07-19T12:30:12+01:00")
+      assertThatJson(message).node("additionalInformation.nomsNumber").isEqualTo("A2483AA")
+      assertThatJson(message).node("additionalInformation.reason").isEqualTo("TRANSFERRED")
+    }
+  }
+
+  @Nested
+  inner class Created {
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/created/A2483AA")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/created/A2483AA")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `sends prisoner created event to the domain topic`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/created/A2483AA")
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isAccepted
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
+
+      val message = readNextDomainEventMessage()
+
+      assertThatJson(message).node("eventType").isEqualTo("test.prisoner-offender-search.prisoner.created")
+      assertThatJson(message).node("version").isEqualTo(1)
+      assertThatJson(message).node("occurredAt").isEqualTo("2022-09-16T11:40:34+01:00") // the fixed clock time
+      assertThatJson(message).node("additionalInformation.nomsNumber").isEqualTo("A2483AA")
+    }
+  }
+
+  @Nested
+  inner class Removed {
+    @Test
+    fun `access forbidden when no authority`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/removed/A2483AA")
+        .exchange()
+        .expectStatus()
+        .isUnauthorized
+    }
+
+    @Test
+    fun `access forbidden when no role`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/removed/A2483AA")
+        .headers(setAuthorisation())
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `sends prisoner removed event to the domain topic`() {
+      webTestClient
+        .put()
+        .uri("/events/prisoner/removed/A2483AA")
+        .headers(setAuthorisation(roles = listOf("ROLE_EVENTS_ADMIN")))
+        .exchange()
+        .expectStatus()
+        .isAccepted
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnDomainQueue() } matches { it == 1 }
+
+      val message = readNextDomainEventMessage()
+
+      assertThatJson(message).node("eventType").isEqualTo("test.prisoner-offender-search.prisoner.removed")
+      assertThatJson(message).node("version").isEqualTo(1)
+      assertThatJson(message).node("occurredAt").isEqualTo("2022-09-16T11:40:34+01:00") // the fixed clock time
+      assertThatJson(message).node("additionalInformation.nomsNumber").isEqualTo("A2483AA")
+    }
   }
 }

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
@@ -6,6 +6,7 @@ import net.minidev.json.JSONArray
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -68,7 +69,11 @@ class RefreshIndexResourceIntTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isAccepted
 
-    await untilCallTo { indexSqsClient.countAllMessagesOnQueue(indexQueueUrl).get() } matches { it!! > 0 }
+    await untilAsserted {
+      verify(indexQueueService).sendRefreshPrisonerMessage("A9999AA")
+      verify(indexQueueService).sendRefreshPrisonerMessage("A7089EY")
+    }
+
     await untilCallTo { indexSqsClient.countAllMessagesOnQueue(indexQueueUrl).get() } matches { it == 0 }
   }
 


### PR DESCRIPTION
This covers some of the additional events which are no longer retried automatically when a publish call fails.