### PR TITLE
SDIT-2724 Add admission date and complexity of needs fields to prisoner search document - CNL active fix

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
@@ -54,11 +54,17 @@ class IndexListenerService(
 
   fun complexityOfNeedChange(message: ComplexityOfNeedEvent, eventType: String) {
     log.info(
-      "Complexity of need change: {} for prisoner {}",
+      "Complexity of need change: {}, active={} for prisoner {}",
       message.level,
+      message.active,
       message.offenderNo,
     )
-    prisonerSynchroniserService.reindexComplexityOfNeed(message.offenderNo, message.level, eventType)
+    val level = if (message.active) {
+      message.level
+    } else {
+      null
+    }
+    prisonerSynchroniserService.reindexComplexityOfNeed(message.offenderNo, level, eventType)
   }
 
   fun externalMovement(message: ExternalPrisonerMovementMessage, eventType: String) = sync(message.bookingId, eventType)

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
@@ -239,11 +239,6 @@ class PrisonerSynchroniserService(
             null,
             eventType = eventType,
           )
-          // TODO are any events needed ?
-//          if (updated) {
-//            prisonerDifferenceService.generateAlertDiffEvent(this.prisoner.alerts, prisonerNo, alerts)
-//            alertsUpdatedEventService.generateAnyEvents(this.prisoner.alerts, alerts, prisoner)
-//          }
         }
     }
 

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/IntegrationTestBase.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/IntegrationTestBase.kt
@@ -491,13 +491,13 @@ fun validAlertsMessage(prisonerNumber: String, eventType: String) =
   }
   """.trimIndent()
 
-fun validComplexityOfNeedMessage(prisonerNumber: String, eventType: String) =
+fun validComplexityOfNeedMessage(prisonerNumber: String, active: Boolean) =
   """
   {
     "Type" : "Notification",
     "MessageId" : "55569f56-8858-5ef8-aeab-ff05da86cf1e",
     "TopicArn" : "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-97e6567cf80881a8a52290ff2c269b08",
-    "Message" : "{\"offenderNo\":\"$prisonerNumber\",\"level\":\"medium\",\"active\":true}",
+    "Message" : "{\"offenderNo\":\"$prisonerNumber\",\"level\":\"medium\",\"active\":$active}",
     "Timestamp" : "2025-03-18T10:53:18.130Z",
     "SignatureVersion" : "1",
     "Signature" : "cqRwyU35w91AyxCnWCE5NXQf49vJON6HKPysfOc9CAsqGwcS6T/UmAsj2FJt1SI48+7L/yg29SbBoizM1hZ+9OtB56SC+OfLE0vMoswIN2BLLwas166VQ4L2uSsxuvrF1SRONmFulvxm/9qWOpu9Zb0LR3C41HSK8EN/JDWUuq69qAhY6tqXmJe/DiDx1ovTu7WOBxNFWvL3kxChz/iYO7m5TFewiieLkA1V6PmZRzDSljMhxpTdxj7Lt4hVTF8j/uVxdvQeoSBysSDTDjvqHFONEftoH/Lpn/7tWxfsbyArqLa/SCODoDt6dpcdiEGaHbZYBTAkSNM3Fg8y7uApJA==",
@@ -505,7 +505,7 @@ fun validComplexityOfNeedMessage(prisonerNumber: String, eventType: String) =
     "UnsubscribeURL" : "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-97e6567cf80881a8a52290ff2c269b08:340b799a-084f-4027-a214-510087556d97",
     "MessageAttributes" : {
       "noTracing" : {"Type":"String","Value":"true"},
-      "eventType" : {"Type":"String","Value":"$eventType"}
+      "eventType" : {"Type":"String","Value":"complexity-of-need.level.changed"}
     }
   }
   """.trimIndent()

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/resource/RefreshIndexResourceIntTest.kt
@@ -22,8 +22,8 @@ import uk.gov.justice.digital.hmpps.prisonersearch.common.model.Prisoner
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.PrisonerBuilder
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.AlertsApiExtension.Companion.alertsApi
-import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.PrisonApiExtension.Companion.prisonApi
 import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.ComplexityOfNeedApiExtension.Companion.complexityOfNeedApi
+import uk.gov.justice.digital.hmpps.prisonersearch.indexer.wiremock.PrisonApiExtension.Companion.prisonApi
 import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.Instant
 import java.time.LocalDate

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/wiremock/ComplexityOfNeedApiMockServer.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/wiremock/ComplexityOfNeedApiMockServer.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.status
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -44,6 +45,13 @@ class ComplexityOfNeedApiMockServer : WireMockServer(8098) {
             """.trimIndent(),
           ),
         ),
+    )
+  }
+
+  fun stubNotFound(prisonerNumber: String) {
+    stubFor(
+      get(urlPathMatching("/v1/complexity-of-need/offender-no/$prisonerNumber"))
+        .willReturn(status(404)),
     )
   }
 }


### PR DESCRIPTION
Fix for an unexpected feature of CNL event: Need to null the CNL (complexity of need level) field if active = false in the event