### PR TITLE
SDIT-2742 Add care needs, smoking and languages fields to prisoner-search fix

### DIFF
--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/nomis/OffenderLanguageDto.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/nomis/OffenderLanguageDto.kt
@@ -3,8 +3,8 @@ package uk.gov.justice.digital.hmpps.prisonersearch.common.nomis
 data class OffenderLanguageDto(
   val type: String,
   val code: String,
-  val readSkill: String,
-  val writeSkill: String,
-  val speakSkill: String,
+  val readSkill: String? = null,
+  val writeSkill: String? = null,
+  val speakSkill: String? = null,
   val interpreterRequested: Boolean,
 )


### PR DESCRIPTION
language skill indicators can be null in Nomis