### PR TITLE
SDIT-2672 Add handler for Nomis event BOOKING-DELETED - fix

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
@@ -24,7 +24,6 @@ import org.springframework.data.elasticsearch.core.query.UpdateQuery
 import org.springframework.data.elasticsearch.core.query.UpdateResponse
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.prisonersearch.common.config.OpenSearchIndexConfiguration.Companion.PRISONER_INDEX
-import uk.gov.justice.digital.hmpps.prisonersearch.common.dps.ComplexityOfNeed
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.Prisoner
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.PrisonerAlert

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepository.kt
@@ -7,7 +7,9 @@ import org.opensearch.OpenSearchStatusException
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest
 import org.opensearch.action.get.GetRequest
 import org.opensearch.action.get.GetResponse
+import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
+import org.opensearch.client.ResponseException
 import org.opensearch.client.RestHighLevelClient
 import org.opensearch.client.core.CountRequest
 import org.opensearch.client.indices.CreateIndexRequest
@@ -22,6 +24,7 @@ import org.springframework.data.elasticsearch.core.query.UpdateQuery
 import org.springframework.data.elasticsearch.core.query.UpdateResponse
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.prisonersearch.common.config.OpenSearchIndexConfiguration.Companion.PRISONER_INDEX
+import uk.gov.justice.digital.hmpps.prisonersearch.common.dps.ComplexityOfNeed
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.Prisoner
 import uk.gov.justice.digital.hmpps.prisonersearch.common.model.PrisonerAlert
@@ -163,8 +166,18 @@ class PrisonerRepository(
     }
   }
 
-  fun delete(prisonerNumber: String) {
-    openSearchRestTemplate.delete(prisonerNumber, IndexCoordinates.of(PRISONER_INDEX))
+  fun delete(prisonerNumber: String): Boolean {
+    val request = Request("DELETE", "/$PRISONER_INDEX/_doc/$prisonerNumber")
+    try {
+      client.lowLevelClient.performRequest(request)
+      return true
+    } catch (e: ResponseException) {
+      log.error("Unexpected response ${e.response} from delete of $prisonerNumber", e)
+      if (e.response.statusLine.statusCode == 404) {
+        return false
+      }
+      throw e
+    }
   }
 
   fun get(prisonerNumber: String): Prisoner? = openSearchRestTemplate

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerService.kt
@@ -92,8 +92,9 @@ class IndexListenerService(
       val offender = nomisService.getOffender(offenderNo = this)
       if (offender == null) {
         log.debug("Delete check: offender ID {} no longer exists, deleting", this)
-        prisonerSynchroniserService.delete(prisonerNumber = this)
-        hmppsDomainEventEmitter.emitPrisonerRemovedEvent(offenderNo = this)
+        if (prisonerSynchroniserService.delete(prisonerNumber = this)) {
+          hmppsDomainEventEmitter.emitPrisonerRemovedEvent(offenderNo = this)
+        }
       } else {
         log.debug("Delete check: offender ID {} still exists, so assuming an alias deletion", this)
         prisonerSynchroniserService.reindexUpdate(offender, eventType)
@@ -104,10 +105,11 @@ class IndexListenerService(
   fun bookingDeleted(message: BookingDeletedMessage, eventType: String) {
     val offender = nomisService.getOffender(message.offenderIdDisplay)
     if (offender == null) {
-      // Last booking was deleted
+      // The last booking was deleted
       log.debug("Booking Delete check: offender ID {} no longer exists, deleting", this)
-      prisonerSynchroniserService.delete(message.offenderIdDisplay)
-      hmppsDomainEventEmitter.emitPrisonerRemovedEvent(message.offenderIdDisplay)
+      if (prisonerSynchroniserService.delete(message.offenderIdDisplay)) {
+        hmppsDomainEventEmitter.emitPrisonerRemovedEvent(message.offenderIdDisplay)
+      }
     } else {
       log.debug("Booking Delete check: offender ID {} still exists, so just update", this)
       prisonerSynchroniserService.reindexUpdate(offender, eventType)

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserService.kt
@@ -307,9 +307,17 @@ class PrisonerSynchroniserService(
     complexityOfNeed = Result.success(getComplexityOfNeed(ob)),
   )
 
-  fun delete(prisonerNumber: String) {
-    prisonerRepository.delete(prisonerNumber)
-    telemetryClient.trackPrisonerEvent(TelemetryEvents.PRISONER_REMOVED, prisonerNumber)
+  fun delete(prisonerNumber: String): Boolean {
+    val deleted = prisonerRepository.delete(prisonerNumber)
+    telemetryClient.trackPrisonerEvent(
+      if (deleted) {
+        TelemetryEvents.PRISONER_REMOVED
+      } else {
+        TelemetryEvents.PRISONER_OPENSEARCH_NO_CHANGE
+      },
+      prisonerNumber,
+    )
+    return deleted
   }
 
   private fun getRestrictedPatient(ob: OffenderBooking) = ob.takeIf { it.assignedLivingUnit?.agencyId == "OUT" }?.let {

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/repository/PrisonerRepositoryTest.kt
@@ -658,14 +658,21 @@ internal class PrisonerRepositoryTest : IntegrationTestBase() {
       prisonerRepository.save(Prisoner().apply { prisonerNumber = "X12345" })
       assertThat(highLevelClient.get(GetRequest(OpenSearchIndexConfiguration.PRISONER_INDEX).id("X12345"), RequestOptions.DEFAULT).isExists).isTrue()
 
-      prisonerRepository.delete(prisonerNumber = "X12345")
+      val result = prisonerRepository.delete(prisonerNumber = "X12345")
 
+      assertThat(result).isTrue()
       assertThat(
         highLevelClient.get(
           GetRequest(OpenSearchIndexConfiguration.PRISONER_INDEX).id("X12345"),
           RequestOptions.DEFAULT,
         ).isExists,
       ).isFalse()
+    }
+
+    @Test
+    fun `deleting prisoner that does not exist`() {
+      val result = prisonerRepository.delete(prisonerNumber = "DOESNOTEXIST")
+      assertThat(result).isFalse()
     }
   }
 

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/IndexListenerServiceTest.kt
@@ -279,10 +279,22 @@ internal class IndexListenerServiceTest {
 
     @Test
     fun `will raise a deletion event on OFFENDER-DELETED event if no longer exists`() {
-      whenever(nomisService.getOffender(any())).thenReturn(null)
+      whenever(nomisService.getOffender("A123BC")).thenReturn(null)
+      whenever(prisonerSynchroniserService.delete("A123BC")).thenReturn(true)
+
       indexListenerService.maybeDeleteOffender(anOffenderChanged("A123BC"), "OFFENDER-DELETED")
 
       verify(hmppsDomainEventEmitter).emitPrisonerRemovedEvent("A123BC")
+    }
+
+    @Test
+    fun `will not raise a deletion event if prisoner never existed`() {
+      whenever(nomisService.getOffender("A123BC")).thenReturn(null)
+      whenever(prisonerSynchroniserService.delete("A123BC")).thenReturn(false)
+
+      indexListenerService.maybeDeleteOffender(anOffenderChanged("A123BC"), "OFFENDER-DELETED")
+
+      verifyNoInteractions(hmppsDomainEventEmitter)
     }
 
     private fun anOffenderChanged(prisonerNumber: String?) = OffenderChangedMessage(

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/PrisonerSynchroniserServiceTest.kt
@@ -1035,12 +1035,27 @@ internal class PrisonerSynchroniserServiceTest {
   @Nested
   inner class Delete {
     @Test
-    fun `will raise a telemetry event`() {
+    fun `will raise a PRISONER_REMOVED telemetry event`() {
+      whenever(prisonerRepository.delete("ABC123D")).thenReturn(true)
+
       service.delete("ABC123D")
 
       verify(telemetryClient).trackEvent(
         TelemetryEvents.PRISONER_REMOVED.name,
         mapOf("prisonerNumber" to "ABC123D"),
+        null,
+      )
+    }
+
+    @Test
+    fun `will raise a PRISONER_OPENSEARCH_NO_CHANGE telemetry event`() {
+      whenever(prisonerRepository.delete("NEVER-EXISTED")).thenReturn(false)
+
+      service.delete("NEVER-EXISTED")
+
+      verify(telemetryClient).trackEvent(
+        TelemetryEvents.PRISONER_OPENSEARCH_NO_CHANGE.name,
+        mapOf("prisonerNumber" to "NEVER-EXISTED"),
         null,
       )
     }


### PR DESCRIPTION
We now need to know whether a deletion actually deleted a prisoner to avoid multiple prisoner-removed events.