### PR TITLE
SDIT-2934 Detect a move booking event better for receive events

### DIFF
--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventService.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventService.kt
@@ -94,6 +94,8 @@ class PrisonerMovementsEventService(
       Released(prisonerNumber, previousPrisonerSnapshot?.prisonId!!)
     } else if (prisoner.isNewAdmissionDueToMoveBooking(previousPrisonerSnapshot)) {
       NewAdmission(prisonerNumber, prisoner.prisonId!!)
+    } else if (prisoner.isAdmissionDueToMoveBooking(previousPrisonerSnapshot)) {
+      NewAdmission(prisonerNumber, prisoner.prisonId!!)
     } else if (
       prisoner.isSomeOtherMovementIn(previousPrisonerSnapshot) ||
       prisoner.isSomeOtherMovementOut(previousPrisonerSnapshot)
@@ -182,6 +184,9 @@ private fun Prisoner.isNewAdmission(previousPrisonerSnapshot: Prisoner?) = this.
   this.bookingId != previousPrisonerSnapshot?.bookingId
 
 private fun Prisoner.isNewAdmissionDueToMoveBooking(previousPrisonerSnapshot: Prisoner?) = previousPrisonerSnapshot?.bookingId == null &&
+  this.status == "ACTIVE IN"
+
+private fun Prisoner.isAdmissionDueToMoveBooking(previousPrisonerSnapshot: Prisoner?) = previousPrisonerSnapshot?.status == "INACTIVE OUT" &&
   this.status == "ACTIVE IN"
 
 private fun Prisoner.isReadmission(previousPrisonerSnapshot: Prisoner?) = this.lastMovementTypeCode == "ADM" &&

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventServiceTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/services/events/PrisonerMovementsEventServiceTest.kt
@@ -30,7 +30,7 @@ import java.time.LocalDateTime
 private const val OFFENDER_NO = "A9460DY"
 
 @JsonTest
-internal class PrisonerMovementsEventServiceTest(@Autowired private val objectMapper: ObjectMapper) {
+internal class PrisonerMovementsEventServiceTest(@param:Autowired private val objectMapper: ObjectMapper) {
   private val domainEventsEmitter = mock<HmppsDomainEventEmitter>()
   private val telemetryClient = mock<TelemetryClient>()
 
@@ -188,6 +188,42 @@ internal class PrisonerMovementsEventServiceTest(@Autowired private val objectMa
     @Test
     internal fun `will emit receive event with reason of new admission for new booking`() {
       val prisoner = prisonerInWithMovedBooking("BXI")
+
+      prisonerMovementsEventService.generateAnyEvents(previousPrisonerSnapshot, prisoner, offenderBooking())
+
+      verify(domainEventsEmitter).emitPrisonerReceiveEvent(
+        offenderNo = OFFENDER_NO,
+        reason = NEW_ADMISSION,
+        prisonId = "BXI",
+      )
+    }
+  }
+
+  @Nested
+  inner class MovedBookingsAfterReturnFromCourt {
+    private val previousPrisonerSnapshot = releasedPrisoner()
+
+    @Test
+    internal fun `will emit receive event with reason of new admission for new booking`() {
+      val prisoner = prisonerInWithMovedBooking("BXI").apply { this.lastMovementTypeCode = "CRT" }
+
+      prisonerMovementsEventService.generateAnyEvents(previousPrisonerSnapshot, prisoner, offenderBooking())
+
+      verify(domainEventsEmitter).emitPrisonerReceiveEvent(
+        offenderNo = OFFENDER_NO,
+        reason = NEW_ADMISSION,
+        prisonId = "BXI",
+      )
+    }
+  }
+
+  @Nested
+  inner class MovedBookingsAfterReturnFromTAP {
+    private val previousPrisonerSnapshot = releasedPrisoner()
+
+    @Test
+    internal fun `will emit receive event with reason of new admission for new booking`() {
+      val prisoner = prisonerInWithMovedBooking("BXI").apply { this.lastMovementTypeCode = "TAP" }
 
       prisonerMovementsEventService.generateAnyEvents(previousPrisonerSnapshot, prisoner, offenderBooking())
 


### PR DESCRIPTION
The last movement code could be anything; for instance, on the moved booking that might have previously been at court