### PR TITLE
MAPB-573 Add lastMovementDate to prisoner index

### DIFF
--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
@@ -144,7 +144,6 @@ class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date of the last movement of the prisoner", example = "2023-05-01")
-  //@DiffableProperty(DiffCategory.LOCATION)
   var lastMovementDate: LocalDate? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT", "TRN"])

--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
@@ -142,6 +142,11 @@ class Prisoner : Diffable<Prisoner> {
   @DiffableProperty(DiffCategory.LOCATION)
   var lastMovementReasonCode: String? = null
 
+  @Field(type = FieldType.Date, format = [DateFormat.date])
+  @Schema(description = "Date of the last movement of the prisoner", example = "2023-05-01")
+  @DiffableProperty(DiffCategory.LOCATION)
+  var lastMovementDate: LocalDate? = null
+
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT", "TRN"])
   @DiffableProperty(DiffCategory.STATUS)
   var inOutStatus: String? = null

--- a/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
+++ b/common/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/common/model/Prisoner.kt
@@ -144,7 +144,7 @@ class Prisoner : Diffable<Prisoner> {
 
   @Field(type = FieldType.Date, format = [DateFormat.date])
   @Schema(description = "Date of the last movement of the prisoner", example = "2023-05-01")
-  @DiffableProperty(DiffCategory.LOCATION)
+  //@DiffableProperty(DiffCategory.LOCATION)
   var lastMovementDate: LocalDate? = null
 
   @Schema(description = "In/Out Status", example = "IN", allowableValues = ["IN", "OUT", "TRN"])

--- a/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
+++ b/hmpps-prisoner-search-indexer/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/translator.kt
@@ -55,6 +55,7 @@ fun Prisoner.translate(
   this.inOutStatus = ob.inOutStatus
   this.lastMovementTypeCode = ob.lastMovementTypeCode
   this.lastMovementReasonCode = ob.lastMovementReasonCode
+  this.lastMovementDate = ob.lastMovementTime?.toLocalDate()
 
   this.category = ob.categoryCode
   this.csra = ob.csra

--- a/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/TranslatorTest.kt
+++ b/hmpps-prisoner-search-indexer/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonersearch/indexer/model/TranslatorTest.kt
@@ -193,6 +193,18 @@ class TranslatorTest {
   }
 
   @Test
+  fun `last movement date is mapped from last movement time`() {
+    val prisoner = Prisoner().translate(
+      ob = OffenderBooking(
+        offenderNo = "A1234AA",
+        offenderId = 1L,
+        lastMovementTime = LocalDateTime.parse("2025-04-23T15:20:26"),
+      ),
+    )
+    assertThat(prisoner.lastMovementDate).isEqualTo("2025-04-23")
+  }
+
+  @Test
   internal fun `current incentive is mapped`() {
     val prisoner = Prisoner().translate(
       ob = aBooking(),


### PR DESCRIPTION
## What
Adds a new `lastMovementDate` (LocalDate) field to the prisoner search index, mapped from the `lastMovementTime` already returned by prison-api's `/api/prisoner-search/offenders/{offenderNo}` endpoint.

## Why
The locations-inside-prison API roll count (`getNumOvernights`) needs the last movement date to decide which CRT/TAP `ACTIVE OUT` prisoners are on overnight leave. Today it makes an extra prison-api call to learn this. Exposing the date on the prisoner index lets that consumer drop the extra round-trip.

## Changes
- `Prisoner` model: new `lastMovementDate` field (`@Field` date, diffable under LOCATION)
- `translator`: `lastMovementDate = ob.lastMovementTime?.toLocalDate()`
- Translator test for the mapping

## Note
A **full reindex** (dev → preprod → prod) is required after deploy to populate the field on existing documents.